### PR TITLE
feat: add SSZ derive macros (#8)

### DIFF
--- a/LeanConsensus/Consensus/Types.lean
+++ b/LeanConsensus/Consensus/Types.lean
@@ -5,7 +5,8 @@
   Types use dependent-typed collections (SszVector, SszList, BytesN)
   to enforce invariants at the type level.
 
-  Manual SSZ instances use SszEncoder for containers (Phase 1a approach).
+  SSZ instances are auto-derived using the custom derive handlers in
+  LeanConsensus.SSZ.Derive.
 -/
 
 import Std.Data.HashMap
@@ -19,6 +20,7 @@ import LeanConsensus.SSZ.Bitlist
 import LeanConsensus.SSZ.Vector
 import LeanConsensus.SSZ.List
 import LeanConsensus.SSZ.Merkleization
+import LeanConsensus.SSZ.Derive
 import LeanConsensus.Consensus.Constants
 
 namespace LeanConsensus.Consensus
@@ -47,33 +49,7 @@ abbrev XmssSignature := BytesN XMSS_SIGNATURE_SIZE
 structure Checkpoint where
   slot : Slot
   root : Root
-  deriving BEq
-
-instance : SszType Checkpoint where
-  sszFixedSize := some 40
-
-instance : SszEncode Checkpoint where
-  sszEncode c :=
-    let enc := { : SszEncoder }
-    let enc := SszEncoder.addField enc c.slot
-    let enc := SszEncoder.addField enc c.root
-    SszEncoder.finalize enc
-
-instance : SszDecode Checkpoint where
-  sszDecode data := do
-    if data.size != 40 then
-      .error (.invalidLength 40 data.size)
-    let slot ← decodeUInt64At data 0
-    let rootData := data.extract 8 40
-    let root ← BytesN.mkChecked rootData
-    .ok { slot, root }
-
-instance : SszHashTreeRoot Checkpoint where
-  hashTreeRoot c :=
-    merkleize #[
-      SszHashTreeRoot.hashTreeRoot c.slot,
-      SszHashTreeRoot.hashTreeRoot c.root
-    ] 2
+  deriving BEq, SszType, SszEncode, SszDecode, SszHashTreeRoot
 
 -- ════════════════════════════════════════════════════════════════
 -- AttestationData
@@ -84,38 +60,7 @@ structure AttestationData where
   headRoot         : Root
   sourceCheckpoint : Checkpoint
   targetCheckpoint : Checkpoint
-  deriving BEq
-
-instance : SszType AttestationData where
-  sszFixedSize := some 120
-
-instance : SszEncode AttestationData where
-  sszEncode a :=
-    let enc := { : SszEncoder }
-    let enc := SszEncoder.addField enc a.slot
-    let enc := SszEncoder.addField enc a.headRoot
-    let enc := SszEncoder.addField enc a.sourceCheckpoint
-    let enc := SszEncoder.addField enc a.targetCheckpoint
-    SszEncoder.finalize enc
-
-instance : SszDecode AttestationData where
-  sszDecode data := do
-    if data.size != 120 then
-      .error (.invalidLength 120 data.size)
-    let slot ← decodeUInt64At data 0
-    let headRoot ← BytesN.mkChecked (data.extract 8 40)
-    let sourceCheckpoint ← SszDecode.sszDecode (data.extract 40 80)
-    let targetCheckpoint ← SszDecode.sszDecode (data.extract 80 120)
-    .ok { slot, headRoot, sourceCheckpoint, targetCheckpoint }
-
-instance : SszHashTreeRoot AttestationData where
-  hashTreeRoot a :=
-    merkleize #[
-      SszHashTreeRoot.hashTreeRoot a.slot,
-      SszHashTreeRoot.hashTreeRoot a.headRoot,
-      SszHashTreeRoot.hashTreeRoot a.sourceCheckpoint,
-      SszHashTreeRoot.hashTreeRoot a.targetCheckpoint
-    ] 4
+  deriving BEq, SszType, SszEncode, SszDecode, SszHashTreeRoot
 
 -- ════════════════════════════════════════════════════════════════
 -- SignedAttestation
@@ -125,38 +70,10 @@ structure SignedAttestation where
   data           : AttestationData
   validatorIndex : ValidatorIndex
   signature      : XmssSignature
-  deriving BEq
-
-instance : SszType SignedAttestation where
-  sszFixedSize := some 3240  -- 120 + 8 + 3112
-
-instance : SszEncode SignedAttestation where
-  sszEncode sa :=
-    let enc := { : SszEncoder }
-    let enc := SszEncoder.addField enc sa.data
-    let enc := SszEncoder.addField enc sa.validatorIndex
-    let enc := SszEncoder.addField enc sa.signature
-    SszEncoder.finalize enc
-
-instance : SszDecode SignedAttestation where
-  sszDecode data := do
-    if data.size != 3240 then
-      .error (.invalidLength 3240 data.size)
-    let attData ← SszDecode.sszDecode (data.extract 0 120)
-    let valIdx ← decodeUInt64At data 120
-    let sig ← BytesN.mkChecked (data.extract 128 3240)
-    .ok { data := attData, validatorIndex := valIdx, signature := sig }
-
-instance : SszHashTreeRoot SignedAttestation where
-  hashTreeRoot sa :=
-    merkleize #[
-      SszHashTreeRoot.hashTreeRoot sa.data,
-      SszHashTreeRoot.hashTreeRoot sa.validatorIndex,
-      SszHashTreeRoot.hashTreeRoot sa.signature
-    ] 4
+  deriving BEq, SszType, SszEncode, SszDecode, SszHashTreeRoot
 
 -- ════════════════════════════════════════════════════════════════
--- LeanMultisigProof
+-- LeanMultisigProof (manual — opaque ByteArray wrapper, non-standard)
 -- ════════════════════════════════════════════════════════════════
 
 structure LeanMultisigProof where
@@ -185,48 +102,10 @@ structure SignedAggregatedAttestation where
   data             : AttestationData
   aggregationBits  : Bitlist MAX_VALIDATORS_PER_SUBNET
   aggregationProof : LeanMultisigProof
-  deriving BEq
-
-instance : SszType SignedAggregatedAttestation where
-  sszFixedSize := none
-
-instance : SszEncode SignedAggregatedAttestation where
-  sszEncode saa :=
-    let enc := { : SszEncoder }
-    let enc := SszEncoder.addField enc saa.data
-    let enc := SszEncoder.addField enc saa.aggregationBits
-    let enc := SszEncoder.addField enc saa.aggregationProof
-    SszEncoder.finalize enc
-
-instance : SszDecode SignedAggregatedAttestation where
-  sszDecode data := do
-    if data.size < 128 then
-      .error (.unexpectedEndOfInput 128 data.size)
-    let attData ← SszDecode.sszDecode (data.extract 0 120)
-    let offset1 ← decodeUInt32At data 120
-    let offset2 ← decodeUInt32At data 124
-    let o1 := offset1.toNat
-    let o2 := offset2.toNat
-    if o1 > o2 then
-      .error (.offsetsNotMonotonic offset1 offset2)
-    if o2 > data.size then
-      .error (.invalidOffset offset2 data.size)
-    let bits ← SszDecode.sszDecode (data.extract o1 o2)
-    let proof ← SszDecode.sszDecode (data.extract o2 data.size)
-    .ok { data := attData, aggregationBits := bits, aggregationProof := proof }
-
-instance : SszHashTreeRoot SignedAggregatedAttestation where
-  hashTreeRoot saa :=
-    let bitChunks := packBits saa.aggregationBits.data
-    let bitLimit := (MAX_VALIDATORS_PER_SUBNET + 255) / 256
-    merkleize #[
-      SszHashTreeRoot.hashTreeRoot saa.data,
-      mixInLength (merkleize bitChunks bitLimit) saa.aggregationBits.length,
-      SszHashTreeRoot.hashTreeRoot saa.aggregationProof
-    ] 4
+  deriving BEq, SszType, SszEncode, SszDecode, SszHashTreeRoot
 
 -- ════════════════════════════════════════════════════════════════
--- BeaconBlockBody
+-- BeaconBlockBody (manual — single-field direct delegation, non-standard)
 -- ════════════════════════════════════════════════════════════════
 
 structure BeaconBlockBody where
@@ -262,42 +141,7 @@ structure BeaconBlock where
   parentRoot    : Root
   stateRoot     : Root
   body          : BeaconBlockBody
-  deriving BEq
-
-instance : SszType BeaconBlock where
-  sszFixedSize := none
-
-instance : SszEncode BeaconBlock where
-  sszEncode blk :=
-    let enc := { : SszEncoder }
-    let enc := SszEncoder.addField enc blk.slot
-    let enc := SszEncoder.addField enc blk.proposerIndex
-    let enc := SszEncoder.addField enc blk.parentRoot
-    let enc := SszEncoder.addField enc blk.stateRoot
-    let enc := SszEncoder.addField enc blk.body
-    SszEncoder.finalize enc
-
-instance : SszDecode BeaconBlock where
-  sszDecode data := do
-    if data.size < 84 then
-      .error (.unexpectedEndOfInput 84 data.size)
-    let slot ← decodeUInt64At data 0
-    let proposerIndex ← decodeUInt64At data 8
-    let parentRoot ← BytesN.mkChecked (data.extract 16 48)
-    let stateRoot ← BytesN.mkChecked (data.extract 48 80)
-    let bodyOffset ← decodeUInt32At data 80
-    let body ← SszDecode.sszDecode (data.extract bodyOffset.toNat data.size)
-    .ok { slot, proposerIndex, parentRoot, stateRoot, body }
-
-instance : SszHashTreeRoot BeaconBlock where
-  hashTreeRoot blk :=
-    merkleize #[
-      SszHashTreeRoot.hashTreeRoot blk.slot,
-      SszHashTreeRoot.hashTreeRoot blk.proposerIndex,
-      SszHashTreeRoot.hashTreeRoot blk.parentRoot,
-      SszHashTreeRoot.hashTreeRoot blk.stateRoot,
-      SszHashTreeRoot.hashTreeRoot blk.body
-    ] 8
+  deriving BEq, SszType, SszEncode, SszDecode, SszHashTreeRoot
 
 -- ════════════════════════════════════════════════════════════════
 -- SignedBeaconBlock
@@ -306,33 +150,7 @@ instance : SszHashTreeRoot BeaconBlock where
 structure SignedBeaconBlock where
   block     : BeaconBlock
   signature : XmssSignature
-  deriving BEq
-
-instance : SszType SignedBeaconBlock where
-  sszFixedSize := none
-
-instance : SszEncode SignedBeaconBlock where
-  sszEncode sbb :=
-    let enc := { : SszEncoder }
-    let enc := SszEncoder.addField enc sbb.block
-    let enc := SszEncoder.addField enc sbb.signature
-    SszEncoder.finalize enc
-
-instance : SszDecode SignedBeaconBlock where
-  sszDecode data := do
-    if data.size < 3116 then
-      .error (.unexpectedEndOfInput 3116 data.size)
-    let blockOffset ← decodeUInt32At data 0
-    let sig ← BytesN.mkChecked (data.extract 4 3116)
-    let block ← SszDecode.sszDecode (data.extract blockOffset.toNat data.size)
-    .ok { block, signature := sig }
-
-instance : SszHashTreeRoot SignedBeaconBlock where
-  hashTreeRoot sbb :=
-    merkleize #[
-      SszHashTreeRoot.hashTreeRoot sbb.block,
-      SszHashTreeRoot.hashTreeRoot sbb.signature
-    ] 2
+  deriving BEq, SszType, SszEncode, SszDecode, SszHashTreeRoot
 
 -- ════════════════════════════════════════════════════════════════
 -- BeaconBlockHeader
@@ -344,41 +162,7 @@ structure BeaconBlockHeader where
   parentRoot    : Root
   stateRoot     : Root
   bodyRoot      : Root
-  deriving BEq
-
-instance : SszType BeaconBlockHeader where
-  sszFixedSize := some 112
-
-instance : SszEncode BeaconBlockHeader where
-  sszEncode h :=
-    let enc := { : SszEncoder }
-    let enc := SszEncoder.addField enc h.slot
-    let enc := SszEncoder.addField enc h.proposerIndex
-    let enc := SszEncoder.addField enc h.parentRoot
-    let enc := SszEncoder.addField enc h.stateRoot
-    let enc := SszEncoder.addField enc h.bodyRoot
-    SszEncoder.finalize enc
-
-instance : SszDecode BeaconBlockHeader where
-  sszDecode data := do
-    if data.size != 112 then
-      .error (.invalidLength 112 data.size)
-    let slot ← decodeUInt64At data 0
-    let proposerIndex ← decodeUInt64At data 8
-    let parentRoot ← BytesN.mkChecked (data.extract 16 48)
-    let stateRoot ← BytesN.mkChecked (data.extract 48 80)
-    let bodyRoot ← BytesN.mkChecked (data.extract 80 112)
-    .ok { slot, proposerIndex, parentRoot, stateRoot, bodyRoot }
-
-instance : SszHashTreeRoot BeaconBlockHeader where
-  hashTreeRoot h :=
-    merkleize #[
-      SszHashTreeRoot.hashTreeRoot h.slot,
-      SszHashTreeRoot.hashTreeRoot h.proposerIndex,
-      SszHashTreeRoot.hashTreeRoot h.parentRoot,
-      SszHashTreeRoot.hashTreeRoot h.stateRoot,
-      SszHashTreeRoot.hashTreeRoot h.bodyRoot
-    ] 8
+  deriving BEq, SszType, SszEncode, SszDecode, SszHashTreeRoot
 
 -- ════════════════════════════════════════════════════════════════
 -- Validator
@@ -391,44 +175,7 @@ structure Validator where
   activationSlot   : Slot
   exitSlot         : Slot
   withdrawableSlot : Slot
-  deriving BEq
-
-instance : SszType Validator where
-  sszFixedSize := some 65
-
-instance : SszEncode Validator where
-  sszEncode v :=
-    let enc := { : SszEncoder }
-    let enc := SszEncoder.addField enc v.pubkey
-    let enc := SszEncoder.addField enc v.effectiveBalance
-    let enc := SszEncoder.addField enc v.slashed
-    let enc := SszEncoder.addField enc v.activationSlot
-    let enc := SszEncoder.addField enc v.exitSlot
-    let enc := SszEncoder.addField enc v.withdrawableSlot
-    SszEncoder.finalize enc
-
-instance : SszDecode Validator where
-  sszDecode data := do
-    if data.size != 65 then
-      .error (.invalidLength 65 data.size)
-    let pubkey ← BytesN.mkChecked (data.extract 0 32)
-    let effectiveBalance ← decodeUInt64At data 32
-    let slashed ← decodeBoolAt data 40
-    let activationSlot ← decodeUInt64At data 41
-    let exitSlot ← decodeUInt64At data 49
-    let withdrawableSlot ← decodeUInt64At data 57
-    .ok { pubkey, effectiveBalance, slashed, activationSlot, exitSlot, withdrawableSlot }
-
-instance : SszHashTreeRoot Validator where
-  hashTreeRoot v :=
-    merkleize #[
-      SszHashTreeRoot.hashTreeRoot v.pubkey,
-      SszHashTreeRoot.hashTreeRoot v.effectiveBalance,
-      SszHashTreeRoot.hashTreeRoot v.slashed,
-      SszHashTreeRoot.hashTreeRoot v.activationSlot,
-      SszHashTreeRoot.hashTreeRoot v.exitSlot,
-      SszHashTreeRoot.hashTreeRoot v.withdrawableSlot
-    ] 8
+  deriving BEq, SszType, SszEncode, SszDecode, SszHashTreeRoot
 
 -- ════════════════════════════════════════════════════════════════
 -- BeaconState
@@ -444,74 +191,7 @@ structure BeaconState where
   justifiedCheckpoint : Checkpoint
   finalizedCheckpoint : Checkpoint
   currentAttestations : SszList MAX_ATTESTATIONS_STATE SignedAggregatedAttestation
-  deriving BEq
-
-instance : SszType BeaconState where
-  sszFixedSize := none
-
-instance : SszEncode BeaconState where
-  sszEncode s :=
-    let enc := { : SszEncoder }
-    let enc := SszEncoder.addField enc s.slot
-    let enc := SszEncoder.addField enc s.latestBlockHeader
-    let enc := SszEncoder.addField enc s.blockRoots
-    let enc := SszEncoder.addField enc s.stateRoots
-    let enc := SszEncoder.addField enc s.validators
-    let enc := SszEncoder.addField enc s.balances
-    let enc := SszEncoder.addField enc s.justifiedCheckpoint
-    let enc := SszEncoder.addField enc s.finalizedCheckpoint
-    let enc := SszEncoder.addField enc s.currentAttestations
-    SszEncoder.finalize enc
-
-instance : SszDecode BeaconState where
-  sszDecode data := do
-    -- Fixed region: 8 + 112 + 2048 + 2048 + 4 + 4 + 40 + 40 + 4 = 4308
-    let fixedSize := 4308
-    if data.size < fixedSize then
-      .error (.unexpectedEndOfInput fixedSize data.size)
-    let slot ← decodeUInt64At data 0
-    let latestBlockHeader ← SszDecode.sszDecode (data.extract 8 120)
-    let blockRoots ← SszDecode.sszDecode (data.extract 120 2168)
-    let stateRoots ← SszDecode.sszDecode (data.extract 2168 4216)
-    let validatorsOff ← decodeUInt32At data 4216
-    let balancesOff ← decodeUInt32At data 4220
-    let justifiedCheckpoint ← SszDecode.sszDecode (data.extract 4224 4264)
-    let finalizedCheckpoint ← SszDecode.sszDecode (data.extract 4264 4304)
-    let attestationsOff ← decodeUInt32At data 4304
-    let vo := validatorsOff.toNat
-    let bo := balancesOff.toNat
-    let ao := attestationsOff.toNat
-    let validators ← SszDecode.sszDecode (data.extract vo bo)
-    let balances ← SszDecode.sszDecode (data.extract bo ao)
-    let currentAttestations ← SszDecode.sszDecode (data.extract ao data.size)
-    .ok {
-      slot, latestBlockHeader, blockRoots, stateRoots,
-      validators, balances, justifiedCheckpoint, finalizedCheckpoint,
-      currentAttestations
-    }
-
-instance : SszHashTreeRoot BeaconState where
-  hashTreeRoot s :=
-    let validatorHashes := s.validators.elems.map SszHashTreeRoot.hashTreeRoot
-    let balanceChunks := pack (encodeFixedList s.balances)
-    merkleize #[
-      SszHashTreeRoot.hashTreeRoot s.slot,
-      SszHashTreeRoot.hashTreeRoot s.latestBlockHeader,
-      merkleize (s.blockRoots.elems.map (·.data)) SLOTS_PER_HISTORICAL_ROOT,
-      merkleize (s.stateRoots.elems.map (·.data)) SLOTS_PER_HISTORICAL_ROOT,
-      mixInLength
-        (merkleize validatorHashes (chunkCountVariable VALIDATOR_REGISTRY_LIMIT))
-        s.validators.elems.size,
-      mixInLength
-        (merkleize balanceChunks (chunkCountFixed VALIDATOR_REGISTRY_LIMIT 8))
-        s.balances.elems.size,
-      SszHashTreeRoot.hashTreeRoot s.justifiedCheckpoint,
-      SszHashTreeRoot.hashTreeRoot s.finalizedCheckpoint,
-      let attHashes := s.currentAttestations.elems.map SszHashTreeRoot.hashTreeRoot
-      mixInLength
-        (merkleize attHashes (chunkCountVariable MAX_ATTESTATIONS_STATE))
-        s.currentAttestations.elems.size
-    ] 16
+  deriving BEq, SszType, SszEncode, SszDecode, SszHashTreeRoot
 
 -- ════════════════════════════════════════════════════════════════
 -- Non-SSZ Internal Types (for fork choice)

--- a/LeanConsensus/SSZ.lean
+++ b/LeanConsensus/SSZ.lean
@@ -14,3 +14,4 @@ import LeanConsensus.SSZ.Bitlist
 import LeanConsensus.SSZ.Vector
 import LeanConsensus.SSZ.List
 import LeanConsensus.SSZ.Merkleization
+import LeanConsensus.SSZ.Derive

--- a/LeanConsensus/SSZ/Bitlist.lean
+++ b/LeanConsensus/SSZ/Bitlist.lean
@@ -10,6 +10,7 @@
 
 import LeanConsensus.SSZ.Error
 import LeanConsensus.SSZ.Types
+import LeanConsensus.SSZ.Merkleization
 
 namespace LeanConsensus.SSZ
 
@@ -122,5 +123,11 @@ instance (maxCap : Nat) : SszEncode (Bitlist maxCap) where
 
 instance (maxCap : Nat) : SszDecode (Bitlist maxCap) where
   sszDecode := Bitlist.sszDecodeImpl
+
+instance (maxCap : Nat) : SszHashTreeRoot (Bitlist maxCap) where
+  hashTreeRoot bl :=
+    let bitChunks := packBits bl.data
+    let bitLimit := (maxCap + 255) / 256
+    mixInLength (merkleize bitChunks bitLimit) bl.length
 
 end LeanConsensus.SSZ

--- a/LeanConsensus/SSZ/Bitvector.lean
+++ b/LeanConsensus/SSZ/Bitvector.lean
@@ -8,6 +8,7 @@
 import LeanConsensus.SSZ.Error
 import LeanConsensus.SSZ.Types
 import LeanConsensus.SSZ.BytesN
+import LeanConsensus.SSZ.Merkleization
 
 namespace LeanConsensus.SSZ
 
@@ -80,5 +81,10 @@ instance (n : Nat) : SszEncode (Bitvector n) where
 
 instance (n : Nat) : SszDecode (Bitvector n) where
   sszDecode data := Bitvector.mkChecked data
+
+instance (n : Nat) : SszHashTreeRoot (Bitvector n) where
+  hashTreeRoot bv :=
+    let chunks := packBits bv.data
+    merkleize chunks ((n + 255) / 256)
 
 end LeanConsensus.SSZ

--- a/LeanConsensus/SSZ/BytesN.lean
+++ b/LeanConsensus/SSZ/BytesN.lean
@@ -69,4 +69,6 @@ instance (n : Nat) : SszEncode (BytesN n) where
 instance (n : Nat) : SszDecode (BytesN n) where
   sszDecode data := BytesN.mkChecked data
 
+instance (n : Nat) : SszPackable (BytesN n) where
+
 end LeanConsensus.SSZ

--- a/LeanConsensus/SSZ/Derive.lean
+++ b/LeanConsensus/SSZ/Derive.lean
@@ -1,0 +1,316 @@
+/-
+  SSZ Derive Handlers
+
+  Custom `deriving` handlers that auto-generate `SszType`, `SszEncode`,
+  `SszDecode`, and `SszHashTreeRoot` instances for structure types.
+
+  These replace ~300 lines of hand-written instances in Consensus/Types.lean
+  with simple `deriving` clauses.
+-/
+
+import Lean
+import LeanConsensus.SSZ.Types
+import LeanConsensus.SSZ.Encode
+import LeanConsensus.SSZ.Decode
+import LeanConsensus.SSZ.Merkleization
+
+open Lean Elab Command Term Meta
+
+namespace LeanConsensus.SSZ.Derive
+
+-- ════════════════════════════════════════════════════════════════
+-- Shared helpers
+-- ════════════════════════════════════════════════════════════════
+
+inductive FieldClass where
+  | fixed (size : Nat)
+  | variable
+
+structure FieldInfo where
+  fieldName : Name
+  fieldType : Expr
+  cls : FieldClass
+
+instance : Inhabited FieldInfo where
+  default := { fieldName := .anonymous, fieldType := .const .anonymous [], cls := .variable }
+
+/-- Extract a Nat from a UInt32 expression.
+    After whnf, a UInt32 value is typically `@OfNat.ofNat UInt32 n inst`
+    where `n` is a raw nat literal. -/
+private def extractUInt32Nat (e : Expr) : Nat :=
+  if e.isAppOf ``OfNat.ofNat then
+    let args := e.getAppArgs
+    if h : args.size > 1 then
+      match args[1] with
+      | .lit (.natVal n) => n
+      | _ => findNatLit e |>.getD 0
+    else findNatLit e |>.getD 0
+  else findNatLit e |>.getD 0
+where
+  findNatLit (e : Expr) : Option Nat :=
+    match e with
+    | .lit (.natVal n) => some n
+    | .app f a =>
+      match findNatLit a with
+      | some n => some n
+      | none => findNatLit f
+    | _ => none
+
+/-- Classify a field type by synthesizing SszType and evaluating sszFixedSize. -/
+def classifyFieldType (fieldType : Expr) : TermElabM FieldClass := do
+  let inst ← synthInstance (← mkAppM ``SszType #[fieldType])
+  let expr ← mkAppOptM ``SszType.sszFixedSize #[fieldType, inst]
+  -- Use full transparency to reduce through defs like XMSS_PUBKEY_SIZE
+  let val ← withTransparency .all <| whnf expr
+  if val.isAppOf ``Option.none then
+    return .variable
+  else if val.isAppOf ``Option.some then
+    let arg ← withTransparency .all <| whnf val.appArg!
+    return .fixed (extractUInt32Nat arg)
+  else
+    return .variable
+
+def analyzeStruct (structName : Name) : TermElabM (Array FieldInfo) := do
+  let env ← getEnv
+  let some info := getStructureInfo? env structName
+    | throwError s!"'{structName}' is not a structure"
+  let mut result : Array FieldInfo := #[]
+  -- Use fieldNames for correct declaration order (fieldInfo may be unordered)
+  for fieldName in info.fieldNames do
+    let some decl := env.find? (structName ++ fieldName)
+      | throwError s!"field projection '{structName ++ fieldName}' not found"
+    let fieldType ← forallTelescopeReducing decl.type fun _ body => pure body
+    let cls ← classifyFieldType fieldType
+    result := result.push { fieldName, fieldType, cls }
+  return result
+
+def nextPow2 (n : Nat) : Nat := Id.run do
+  if n <= 1 then return 1
+  let mut p := 1
+  while p < n do
+    p := p * 2
+  return p
+
+/-- Convert a field type Expr to Syntax for type annotation using delaboration. -/
+def fieldTypeToSyntax (e : Expr) : TermElabM (TSyntax `term) :=
+  Lean.PrettyPrinter.delab e
+
+-- ════════════════════════════════════════════════════════════════
+-- SszType deriving handler
+-- ════════════════════════════════════════════════════════════════
+
+def mkSszTypeHandler (declNames : Array Name) : CommandElabM Bool := do
+  if declNames.size != 1 then return false
+  let declName := declNames[0]!
+  let fields ← liftTermElabM <| analyzeStruct declName
+  let mut allFixed := true
+  let mut totalSize : Nat := 0
+  for fi in fields do
+    match fi.cls with
+    | .fixed size => totalSize := totalSize + size
+    | .variable => allFixed := false
+  let typeName := mkIdent declName
+  if allFixed then
+    let sizeStx := Syntax.mkNumLit (toString totalSize)
+    elabCommand (← `(instance : LeanConsensus.SSZ.SszType $typeName where
+      sszFixedSize := some $sizeStx))
+  else
+    elabCommand (← `(instance : LeanConsensus.SSZ.SszType $typeName where
+      sszFixedSize := none))
+  return true
+
+-- ════════════════════════════════════════════════════════════════
+-- SszEncode deriving handler
+-- ════════════════════════════════════════════════════════════════
+
+def mkSszEncodeHandler (declNames : Array Name) : CommandElabM Bool := do
+  if declNames.size != 1 then return false
+  let declName := declNames[0]!
+  let fields ← liftTermElabM <| analyzeStruct declName
+  let typeName := mkIdent declName
+  let xId := mkIdent `x
+  let encId := mkIdent `enc
+
+  let mut body : TSyntax `term ← `(LeanConsensus.SSZ.SszEncoder.finalize $encId)
+  for fi in fields.reverse do
+    let fieldAccess := mkIdent fi.fieldName
+    body ← `(let $encId := LeanConsensus.SSZ.SszEncoder.addField $encId ($xId).$fieldAccess; $body)
+  body ← `(let $encId := { : LeanConsensus.SSZ.SszEncoder }; $body)
+
+  elabCommand (← `(instance : LeanConsensus.SSZ.SszEncode $typeName where
+    sszEncode := fun $xId => $body))
+  return true
+
+-- ════════════════════════════════════════════════════════════════
+-- SszDecode deriving handler
+-- ════════════════════════════════════════════════════════════════
+
+/-- Build struct literal syntax: TypeName.mk f1 f2 ... -/
+def mkStructLit (typeName : TSyntax `ident) (fieldNames : Array Name) :
+    CommandElabM (TSyntax `term) := do
+  let ctorId := mkIdent (typeName.getId ++ `mk)
+  -- Build nested application: ((((ctor f1) f2) f3) ...)
+  let mut result : TSyntax `term := ⟨ctorId⟩
+  for fn in fieldNames do
+    let fId : TSyntax `term := ⟨mkIdent fn⟩
+    result ← `($result $fId)
+  return result
+
+def mkSszDecodeHandler (declNames : Array Name) : CommandElabM Bool := do
+  if declNames.size != 1 then return false
+  let declName := declNames[0]!
+  let fields ← liftTermElabM <| analyzeStruct declName
+  let typeName := mkIdent declName
+
+  -- Pre-compute field type syntax for type annotations in sszDecode calls
+  let fieldTypeSyntaxes ← liftTermElabM do
+    fields.mapM fun fi => fieldTypeToSyntax fi.fieldType
+
+  let mut allFixed := true
+  let mut fixedRegionSize : Nat := 0
+  for fi in fields do
+    match fi.cls with
+    | .fixed size => fixedRegionSize := fixedRegionSize + size
+    | .variable =>
+      allFixed := false
+      fixedRegionSize := fixedRegionSize + 4
+
+  let dataId := mkIdent `data
+  let decId := mkIdent `dec
+  let fieldNames := fields.map (·.fieldName)
+
+  if allFixed then
+    let totalSizeStx := Syntax.mkNumLit (toString fixedRegionSize)
+
+    let structLit ← mkStructLit typeName fieldNames
+    let mut body : TSyntax `term ← `(Except.ok $structLit)
+
+    -- Build Except.bind chain from last field to first
+    for i' in [:fields.size] do
+      let i := fields.size - 1 - i'
+      let fi : FieldInfo := fields[i]!
+      let ftStx := fieldTypeSyntaxes[i]!
+      let fId := mkIdent fi.fieldName
+      let pairId := mkIdent (.mkSimple s!"{fi.fieldName}_pair")
+      match fi.cls with
+      | .fixed size =>
+        let sizeStx := Syntax.mkNumLit (toString size)
+        body ← `(
+          Except.bind (LeanConsensus.SSZ.SszDecoder.readFixed $decId $sizeStx) fun $pairId =>
+          let $decId := Prod.snd $pairId
+          Except.bind (LeanConsensus.SSZ.SszDecode.sszDecode (α := $ftStx) (Prod.fst $pairId)) fun $fId =>
+          $body)
+      | .variable => pure ()  -- unreachable in allFixed path
+
+    body ← `(
+      let $decId := LeanConsensus.SSZ.SszDecoder.new $dataId
+      $body)
+
+    elabCommand (← `(instance : LeanConsensus.SSZ.SszDecode $typeName where
+      sszDecode := fun $dataId =>
+        if ByteArray.size $dataId != $totalSizeStx then
+          Except.error (LeanConsensus.SSZ.SszError.invalidLength $totalSizeStx (ByteArray.size $dataId))
+        else
+          $body))
+  else
+    -- Mixed: Phase 1 reads fixed fields + offsets, Phase 2 decodes variable fields
+    let fixedSizeStx := Syntax.mkNumLit (toString fixedRegionSize)
+    let varSlicesId := mkIdent `varSlices
+
+    let mut varCount : Nat := 0
+    for fi in fields do
+      match fi.cls with
+      | .variable => varCount := varCount + 1
+      | _ => pure ()
+
+    let structLit ← mkStructLit typeName fieldNames
+    let mut body : TSyntax `term ← `(Except.ok $structLit)
+
+    -- Phase 2: decode variable fields from varSlices (in reverse)
+    let mut varIdx := varCount
+    for i' in [:fields.size] do
+      let i := fields.size - 1 - i'
+      let fi : FieldInfo := fields[i]!
+      match fi.cls with
+      | .variable =>
+        varIdx := varIdx - 1
+        let fId := mkIdent fi.fieldName
+        let ftStx := fieldTypeSyntaxes[i]!
+        let idxStx := Syntax.mkNumLit (toString varIdx)
+        body ← `(
+          Except.bind (LeanConsensus.SSZ.SszDecode.sszDecode (α := $ftStx) ($varSlicesId[$idxStx]!)) fun $fId =>
+          $body)
+      | _ => pure ()
+
+    -- extractVariableSlices
+    body ← `(
+      Except.bind (LeanConsensus.SSZ.SszDecoder.extractVariableSlices $decId) fun $varSlicesId =>
+      $body)
+
+    -- Phase 1: readFixed for fixed fields, readOffset for variable fields (in reverse)
+    for i' in [:fields.size] do
+      let i := fields.size - 1 - i'
+      let fi : FieldInfo := fields[i]!
+      match fi.cls with
+      | .fixed size =>
+        let fId := mkIdent fi.fieldName
+        let ftStx := fieldTypeSyntaxes[i]!
+        let pairId := mkIdent (.mkSimple s!"{fi.fieldName}_pair")
+        let sizeStx := Syntax.mkNumLit (toString size)
+        body ← `(
+          Except.bind (LeanConsensus.SSZ.SszDecoder.readFixed $decId $sizeStx) fun $pairId =>
+          let $decId := Prod.snd $pairId
+          Except.bind (LeanConsensus.SSZ.SszDecode.sszDecode (α := $ftStx) (Prod.fst $pairId)) fun $fId =>
+          $body)
+      | .variable =>
+        body ← `(
+          Except.bind (LeanConsensus.SSZ.SszDecoder.readOffset $decId) fun $decId =>
+          $body)
+
+    body ← `(
+      let $decId := LeanConsensus.SSZ.SszDecoder.new $dataId
+      $body)
+
+    elabCommand (← `(instance : LeanConsensus.SSZ.SszDecode $typeName where
+      sszDecode := fun $dataId =>
+        if ByteArray.size $dataId < $fixedSizeStx then
+          Except.error (LeanConsensus.SSZ.SszError.unexpectedEndOfInput $fixedSizeStx (ByteArray.size $dataId))
+        else
+          $body))
+
+  return true
+
+-- ════════════════════════════════════════════════════════════════
+-- SszHashTreeRoot deriving handler
+-- ════════════════════════════════════════════════════════════════
+
+def mkSszHashTreeRootHandler (declNames : Array Name) : CommandElabM Bool := do
+  if declNames.size != 1 then return false
+  let declName := declNames[0]!
+  let fields ← liftTermElabM <| analyzeStruct declName
+  let typeName := mkIdent declName
+  let xId := mkIdent `x
+  let limit := nextPow2 fields.size
+  let limitStx := Syntax.mkNumLit (toString limit)
+
+  let hashExprs : Array (TSyntax `term) ← fields.mapM fun fi => do
+    let fieldAccess := mkIdent fi.fieldName
+    `(LeanConsensus.SSZ.SszHashTreeRoot.hashTreeRoot ($xId).$fieldAccess)
+
+  let arrayStx ← `(#[$[$hashExprs],*])
+
+  elabCommand (← `(instance : LeanConsensus.SSZ.SszHashTreeRoot $typeName where
+    hashTreeRoot := fun $xId =>
+      LeanConsensus.SSZ.merkleize $arrayStx $limitStx))
+  return true
+
+-- ════════════════════════════════════════════════════════════════
+-- Registration
+-- ════════════════════════════════════════════════════════════════
+
+initialize registerDerivingHandler ``LeanConsensus.SSZ.SszType mkSszTypeHandler
+initialize registerDerivingHandler ``LeanConsensus.SSZ.SszEncode mkSszEncodeHandler
+initialize registerDerivingHandler ``LeanConsensus.SSZ.SszDecode mkSszDecodeHandler
+initialize registerDerivingHandler ``LeanConsensus.SSZ.SszHashTreeRoot mkSszHashTreeRootHandler
+
+end LeanConsensus.SSZ.Derive

--- a/LeanConsensus/SSZ/Encode.lean
+++ b/LeanConsensus/SSZ/Encode.lean
@@ -82,6 +82,16 @@ instance : SszType Bool where sszFixedSize := some 1
 instance : SszEncode Bool where sszEncode := encodeBool
 
 -- ════════════════════════════════════════════════════════════════
+-- SszPackable instances for primitive types (basic SSZ types)
+-- ════════════════════════════════════════════════════════════════
+
+instance : SszPackable UInt8 where
+instance : SszPackable UInt16 where
+instance : SszPackable UInt32 where
+instance : SszPackable UInt64 where
+instance : SszPackable Bool where
+
+-- ════════════════════════════════════════════════════════════════
 -- Two-Pass Container Encoder
 -- ════════════════════════════════════════════════════════════════
 

--- a/LeanConsensus/SSZ/List.lean
+++ b/LeanConsensus/SSZ/List.lean
@@ -10,6 +10,7 @@ import LeanConsensus.SSZ.Error
 import LeanConsensus.SSZ.Types
 import LeanConsensus.SSZ.Encode
 import LeanConsensus.SSZ.Decode
+import LeanConsensus.SSZ.Merkleization
 
 namespace LeanConsensus.SSZ
 
@@ -141,5 +142,22 @@ instance {α : Type} [SszDecode α] (maxCap : Nat) : SszDecode (SszList maxCap �
     match SszType.sszFixedSize (α := α) with
     | some elemSize => decodeFixedList data elemSize.toNat
     | none          => decodeVariableList data
+
+/-- SszHashTreeRoot for SszList of packable (basic) types: pack serialized data + mixInLength. -/
+instance (priority := 100) {α : Type} [SszPackable α] (maxCap : Nat) : SszHashTreeRoot (SszList maxCap α) where
+  hashTreeRoot l :=
+    let serialized := l.elems.foldl (init := ByteArray.empty) fun acc elem =>
+      acc ++ SszEncode.sszEncode elem
+    let chunks := pack serialized
+    let limit := match SszType.sszFixedSize (α := α) with
+      | some elemSize => chunkCountFixed maxCap elemSize.toNat
+      | none => maxCap
+    mixInLength (merkleize chunks limit) l.elems.size
+
+/-- SszHashTreeRoot for SszList of composite types: hash each element + mixInLength. -/
+instance (priority := 50) {α : Type} [SszHashTreeRoot α] (maxCap : Nat) : SszHashTreeRoot (SszList maxCap α) where
+  hashTreeRoot l :=
+    let chunks := l.elems.map SszHashTreeRoot.hashTreeRoot
+    mixInLength (merkleize chunks (chunkCountVariable maxCap)) l.elems.size
 
 end LeanConsensus.SSZ

--- a/LeanConsensus/SSZ/Types.lean
+++ b/LeanConsensus/SSZ/Types.lean
@@ -46,4 +46,9 @@ def isFixedSize {α : Type} [inst : SszType α] : Bool :=
 def getFixedSize {α : Type} [inst : SszType α] : Option UInt32 :=
   inst.sszFixedSize
 
+/-- Marker typeclass for SSZ "basic" types whose serialized bytes can be packed
+    directly into chunks for hash_tree_root (as opposed to composite types where
+    each element is hashed individually). -/
+class SszPackable (α : Type) extends SszEncode α
+
 end LeanConsensus.SSZ

--- a/LeanConsensus/SSZ/Vector.lean
+++ b/LeanConsensus/SSZ/Vector.lean
@@ -10,6 +10,7 @@ import LeanConsensus.SSZ.Error
 import LeanConsensus.SSZ.Types
 import LeanConsensus.SSZ.Encode
 import LeanConsensus.SSZ.Decode
+import LeanConsensus.SSZ.Merkleization
 
 namespace LeanConsensus.SSZ
 
@@ -125,5 +126,21 @@ instance {α : Type} [SszDecode α] (n : Nat) : SszDecode (SszVector n α) where
     match SszType.sszFixedSize (α := α) with
     | some elemSize => decodeFixedVector data elemSize.toNat
     | none          => decodeVariableVector data
+
+/-- SszHashTreeRoot for SszVector of packable (basic) types: pack serialized data. -/
+instance (priority := 100) {α : Type} [SszPackable α] (n : Nat) : SszHashTreeRoot (SszVector n α) where
+  hashTreeRoot v :=
+    let serialized := v.elems.foldl (init := ByteArray.empty) fun acc elem =>
+      acc ++ SszEncode.sszEncode elem
+    let chunks := pack serialized
+    match SszType.sszFixedSize (α := α) with
+    | some elemSize => merkleize chunks (chunkCountFixed n elemSize.toNat)
+    | none => merkleize chunks n
+
+/-- SszHashTreeRoot for SszVector of composite types: hash each element individually. -/
+instance (priority := 50) {α : Type} [SszHashTreeRoot α] (n : Nat) : SszHashTreeRoot (SszVector n α) where
+  hashTreeRoot v :=
+    let chunks := v.elems.map SszHashTreeRoot.hashTreeRoot
+    merkleize chunks n
 
 end LeanConsensus.SSZ


### PR DESCRIPTION
## Summary

- Implement custom `deriving` handlers for `SszType`, `SszEncode`, `SszDecode`, and `SszHashTreeRoot` using Lean 4 metaprogramming
- Add `SszPackable` marker typeclass for basic SSZ types, enabling priority-based dispatch for `SszHashTreeRoot` on `SszVector`/`SszList` (pack path vs per-element hash)
- Add missing `SszHashTreeRoot` instances for `Bitvector`, `Bitlist`, `SszVector`, `SszList`
- Migrate 9 consensus types from ~300 lines of hand-written instances to `deriving` clauses
- Keep `LeanMultisigProof` and `BeaconBlockBody` manual (non-standard encoding patterns)

## Files changed

| File | Change |
|------|--------|
| `LeanConsensus/SSZ/Derive.lean` | **New** — derive handlers (316 lines) |
| `LeanConsensus/SSZ/Types.lean` | Add `SszPackable` class |
| `LeanConsensus/SSZ/Encode.lean` | Add `SszPackable` instances for primitives |
| `LeanConsensus/SSZ/BytesN.lean` | Add `SszPackable` instance |
| `LeanConsensus/SSZ/Bitvector.lean` | Add `SszHashTreeRoot` instance |
| `LeanConsensus/SSZ/Bitlist.lean` | Add `SszHashTreeRoot` instance |
| `LeanConsensus/SSZ/Vector.lean` | Add `SszHashTreeRoot` instances (pack + composite) |
| `LeanConsensus/SSZ/List.lean` | Add `SszHashTreeRoot` instances (pack + composite) |
| `LeanConsensus/SSZ.lean` | Add `Derive` import |
| `LeanConsensus/Consensus/Types.lean` | Replace manual instances with `deriving` (508→213 lines) |

## Test plan

- [x] `lake build` — compiles cleanly
- [x] `lake exe test-runner` — all 72 tests pass
- [x] `lake build Proofs` — proof stubs compile
- [x] Verified encode sizes match manual instances (Checkpoint=40, AttestationData=120, Validator=65, etc.)
- [x] Roundtrip tests pass for all migrated types including mixed containers (SignedAggregatedAttestation, BeaconBlock, BeaconState)

🤖 Generated with [Claude Code](https://claude.com/claude-code)