### PR TITLE
feat: add computeSigningRoot and computeDomain

### DIFF
--- a/LeanConsensus.lean
+++ b/LeanConsensus.lean
@@ -7,4 +7,5 @@
 import LeanConsensus.SSZ
 import LeanConsensus.Consensus.Constants
 import LeanConsensus.Consensus.Types
+import LeanConsensus.Consensus.Signing
 import LeanConsensus.Crypto.Sha256

--- a/LeanConsensus/Consensus/Signing.lean
+++ b/LeanConsensus/Consensus/Signing.lean
@@ -1,0 +1,89 @@
+/-
+  Signing — computeSigningRoot and computeDomain
+
+  Per the Ethereum consensus spec:
+  - ForkData and SigningData are SSZ containers used to derive signing domains
+  - computeDomain creates a 32-byte domain from a domain type + fork version + genesis root
+  - computeSigningRoot creates the message root that validators actually sign
+-/
+
+import LeanConsensus.SSZ.Types
+import LeanConsensus.SSZ.BytesN
+import LeanConsensus.SSZ.Encode
+import LeanConsensus.SSZ.Merkleization
+import LeanConsensus.SSZ.Derive
+import LeanConsensus.Consensus.Constants
+
+namespace LeanConsensus.Consensus
+
+open LeanConsensus.SSZ
+
+-- ════════════════════════════════════════════════════════════════
+-- ForkData — SSZ container for domain computation
+-- ════════════════════════════════════════════════════════════════
+
+/-- SSZ container used to compute the fork data root for domain derivation.
+    Fields: 4-byte fork version + 32-byte genesis validators root. -/
+structure ForkData where
+  currentVersion        : Bytes4
+  genesisValidatorsRoot : Bytes32
+  deriving SszType, SszEncode, SszDecode, SszHashTreeRoot
+
+-- ════════════════════════════════════════════════════════════════
+-- SigningData — SSZ container for signing root computation
+-- ════════════════════════════════════════════════════════════════
+
+/-- SSZ container that wraps an object root and domain for signing.
+    The hash_tree_root of this container is the actual signing root. -/
+structure SigningData where
+  objectRoot : Bytes32
+  domain     : Bytes32
+  deriving SszType, SszEncode, SszDecode, SszHashTreeRoot
+
+-- ════════════════════════════════════════════════════════════════
+-- Helpers
+-- ════════════════════════════════════════════════════════════════
+
+/-- Wrap a ByteArray as Bytes32, falling back to zero if the size is wrong.
+    In practice, SHA-256 output is always 32 bytes so the fallback is unreachable. -/
+private def toBytes32 (data : ByteArray) : Bytes32 :=
+  if h : data.size = 32 then ⟨data, h⟩ else BytesN.zero 32
+
+-- ════════════════════════════════════════════════════════════════
+-- computeDomain
+-- ════════════════════════════════════════════════════════════════
+
+/-- Compute a signing domain per the Ethereum consensus spec.
+
+    domain = domainType (4 bytes LE) ++ forkDataRoot[0..28]
+
+    where forkDataRoot = hash_tree_root(ForkData{forkVersion, genesisValidatorsRoot}). -/
+def computeDomain (domainType : UInt32) (forkVersion : Bytes4) (genesisValidatorsRoot : Bytes32) : Bytes32 :=
+  let forkData : ForkData := {
+    currentVersion := forkVersion
+    genesisValidatorsRoot := genesisValidatorsRoot
+  }
+  let forkDataRoot := SszHashTreeRoot.hashTreeRoot forkData
+  let domainTypeBytes := encodeUInt32 domainType
+  let domainBytes := domainTypeBytes ++ forkDataRoot.extract 0 28
+  if h : domainBytes.size = 32 then ⟨domainBytes, h⟩
+  else BytesN.zero 32  -- unreachable: 4 + 28 = 32
+
+-- ════════════════════════════════════════════════════════════════
+-- computeSigningRoot
+-- ════════════════════════════════════════════════════════════════
+
+/-- Compute the signing root for an SSZ object and domain.
+
+    signingRoot = hash_tree_root(SigningData{hash_tree_root(object), domain})
+
+    This is the 32-byte message that validators sign with their XMSS keys. -/
+def computeSigningRoot {α : Type} [SszHashTreeRoot α] (sszObject : α) (domain : Bytes32) : Bytes32 :=
+  let objectRoot := toBytes32 (SszHashTreeRoot.hashTreeRoot sszObject)
+  let signingData : SigningData := {
+    objectRoot := objectRoot
+    domain := domain
+  }
+  toBytes32 (SszHashTreeRoot.hashTreeRoot signingData)
+
+end LeanConsensus.Consensus

--- a/test/Test/Consensus/Signing.lean
+++ b/test/Test/Consensus/Signing.lean
@@ -1,0 +1,106 @@
+/-
+  Consensus Signing Tests — computeDomain and computeSigningRoot
+-/
+
+import LeanConsensus.Consensus.Signing
+import LeanConsensus.Consensus.Constants
+import LeanConsensus.Consensus.Types
+
+namespace Test.Consensus.Signing
+
+open LeanConsensus.SSZ
+open LeanConsensus.Consensus
+
+def check (name : String) (condition : Bool) : IO (Nat × Nat) := do
+  if condition then
+    IO.println s!"  ✓ {name}"
+    return (1, 0)
+  else
+    IO.println s!"  ✗ {name}"
+    return (1, 1)
+
+def runTests : IO (Nat × Nat) := do
+  IO.println "\n── Consensus Signing ──"
+  let mut total := 0
+  let mut failures := 0
+
+  -- ForkData SSZ: 4 + 32 = 36 bytes fixed
+  let fv : Bytes4 := BytesN.zero 4
+  let gr : Bytes32 := Bytes32.zero
+  let fd : ForkData := { currentVersion := fv, genesisValidatorsRoot := gr }
+  let encoded := SszEncode.sszEncode fd
+  let (t, f) ← check "ForkData encode size = 36" (encoded.size == 36)
+  total := total + t; failures := failures + f
+
+  -- ForkData roundtrip
+  let decoded := SszDecode.sszDecode (α := ForkData) encoded
+  let (t, f) ← check "ForkData roundtrip" (match decoded with
+    | .ok fd' => SszEncode.sszEncode fd' == encoded
+    | .error _ => false)
+  total := total + t; failures := failures + f
+
+  -- SigningData SSZ: 32 + 32 = 64 bytes fixed
+  let sd : SigningData := { objectRoot := Bytes32.zero, domain := Bytes32.zero }
+  let encoded := SszEncode.sszEncode sd
+  let (t, f) ← check "SigningData encode size = 64" (encoded.size == 64)
+  total := total + t; failures := failures + f
+
+  -- SigningData roundtrip
+  let decoded := SszDecode.sszDecode (α := SigningData) encoded
+  let (t, f) ← check "SigningData roundtrip" (match decoded with
+    | .ok sd' => SszEncode.sszEncode sd' == encoded
+    | .error _ => false)
+  total := total + t; failures := failures + f
+
+  -- computeDomain produces a 32-byte result
+  let domain := computeDomain DOMAIN_BEACON_PROPOSER fv gr
+  let (t, f) ← check "computeDomain produces Bytes32" (domain.data.size == 32)
+  total := total + t; failures := failures + f
+
+  -- computeDomain: first 4 bytes are the domain type (LE)
+  let (t, f) ← check "computeDomain first 4 bytes = domainType LE" (
+    domain.data.get! 0 == 0x00 &&
+    domain.data.get! 1 == 0x00 &&
+    domain.data.get! 2 == 0x00 &&
+    domain.data.get! 3 == 0x00)
+  total := total + t; failures := failures + f
+
+  -- computeDomain with attester domain type
+  let attDomain := computeDomain DOMAIN_BEACON_ATTESTER fv gr
+  let (t, f) ← check "computeDomain attester first byte = 0x00" (
+    attDomain.data.get! 0 == 0x00 &&
+    attDomain.data.get! 1 == 0x00 &&
+    attDomain.data.get! 2 == 0x00 &&
+    attDomain.data.get! 3 == 0x01)
+  total := total + t; failures := failures + f
+
+  -- Different domain types produce different domains
+  let (t, f) ← check "different domain types → different domains" (
+    !(domain == attDomain))
+  total := total + t; failures := failures + f
+
+  -- computeSigningRoot produces a 32-byte result
+  let cp : Checkpoint := { slot := 42, root := Bytes32.zero }
+  let sigRoot := computeSigningRoot cp domain
+  let (t, f) ← check "computeSigningRoot produces Bytes32" (sigRoot.data.size == 32)
+  total := total + t; failures := failures + f
+
+  -- computeSigningRoot is deterministic
+  let sigRoot2 := computeSigningRoot cp domain
+  let (t, f) ← check "computeSigningRoot is deterministic" (sigRoot == sigRoot2)
+  total := total + t; failures := failures + f
+
+  -- Different objects produce different signing roots
+  let cp2 : Checkpoint := { slot := 43, root := Bytes32.zero }
+  let sigRoot3 := computeSigningRoot cp2 domain
+  let (t, f) ← check "different objects → different signing roots" (!(sigRoot == sigRoot3))
+  total := total + t; failures := failures + f
+
+  -- Different domains produce different signing roots
+  let sigRoot4 := computeSigningRoot cp attDomain
+  let (t, f) ← check "different domains → different signing roots" (!(sigRoot == sigRoot4))
+  total := total + t; failures := failures + f
+
+  return (total, failures)
+
+end Test.Consensus.Signing

--- a/test/TestMain.lean
+++ b/test/TestMain.lean
@@ -13,6 +13,7 @@ import Test.SSZ.Bitlist
 import Test.SSZ.Vector
 import Test.SSZ.Merkleization
 import Test.Consensus.Types
+import Test.Consensus.Signing
 
 def main : IO Unit := do
   IO.println "═══════════════════════════════════════════"
@@ -52,6 +53,10 @@ def main : IO Unit := do
 
   -- Consensus Types tests
   let (t, f) ← Test.Consensus.Types.runTests
+  total := total + t; failures := failures + f
+
+  -- Consensus Signing tests
+  let (t, f) ← Test.Consensus.Signing.runTests
   total := total + t; failures := failures + f
 
   IO.println "═══════════════════════════════════════════"


### PR DESCRIPTION
## Summary
- Implement `ForkData` and `SigningData` SSZ containers with auto-derived instances
- Add `computeDomain`: derives 32-byte signing domain from domain type + fork version + genesis root
- Add `computeSigningRoot`: produces the message root validators sign via `hash_tree_root(SigningData)`
- Pure Lean implementation with no FFI dependencies

Closes #14

## Test plan
- [x] ForkData encode size (36 bytes) and roundtrip
- [x] SigningData encode size (64 bytes) and roundtrip
- [x] computeDomain byte-order verification (LE domain type in first 4 bytes)
- [x] Different domain types produce different domains
- [x] computeSigningRoot determinism, different objects/domains produce different roots
- [x] All 84 tests pass (72 existing + 12 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)