### PR TITLE
feat: add LeanSig @[extern] bindings for XMSS signatures

### DIFF
--- a/LeanConsensus.lean
+++ b/LeanConsensus.lean
@@ -9,3 +9,4 @@ import LeanConsensus.Consensus.Constants
 import LeanConsensus.Consensus.Types
 import LeanConsensus.Consensus.Signing
 import LeanConsensus.Crypto.Sha256
+import LeanConsensus.Crypto.LeanSig

--- a/LeanConsensus/Crypto/LeanSig.lean
+++ b/LeanConsensus/Crypto/LeanSig.lean
@@ -1,14 +1,67 @@
 /-
-  leanSig — XMSS Signature FFI Bindings (Phase 2 stub)
+  leanSig — XMSS Signature FFI Bindings
 
-  Will implement:
-  - Opaque handle types for private/public keys
-  - @[extern] bindings for keygen, sign, verify
-  - Key serialization/deserialization
+  Declares opaque handle types and @[extern] functions matching the C ABI
+  in ffi/lean_sig.c. All operations are IO since they call into native code
+  that manages mutable XMSS key state.
+
+  The C wrappers take owned references (lean_object *), so no @& annotations
+  are used for opaque handle arguments.
 -/
 
 namespace LeanConsensus.Crypto.LeanSig
 
--- Phase 2: opaque handle types + @[extern] bindings
+-- ════════════════════════════════════════════════════════════════
+-- Opaque handle types (standard Lean 4 FFI pattern)
+-- ════════════════════════════════════════════════════════════════
+
+/-- Opaque XMSS private key handle. Backed by a C pointer with a finalizer. -/
+opaque PrivateKeyPointed : NonemptyType
+def PrivateKey : Type := PrivateKeyPointed.type
+instance : Nonempty PrivateKey := PrivateKeyPointed.property
+
+/-- Opaque XMSS public key handle. Backed by a C pointer with a finalizer. -/
+opaque PublicKeyPointed : NonemptyType
+def PublicKey : Type := PublicKeyPointed.type
+instance : Nonempty PublicKey := PublicKeyPointed.property
+
+-- ════════════════════════════════════════════════════════════════
+-- @[extern] bindings (map to lean_sig.c wrappers)
+-- ════════════════════════════════════════════════════════════════
+
+/-- Generate an XMSS keypair for the given epoch range.
+    Returns (privateKey, publicKey). -/
+@[extern "lean_sig_keygen_wrapper"]
+opaque keygen (activationEpoch : UInt32) (numActiveEpochs : UInt32) : IO (PrivateKey × PublicKey)
+
+/-- Sign a 32-byte message with the private key at the given epoch.
+    Each epoch can only be signed once (XMSS is stateful). -/
+@[extern "lean_sig_sign_wrapper"]
+opaque sign (sk : PrivateKey) (epoch : UInt32) (message : ByteArray) : IO ByteArray
+
+/-- Verify a signature against a serialized public key, epoch, and message.
+    The public key is passed as raw bytes (from exportPublicKey), not as an opaque handle. -/
+@[extern "lean_sig_verify_wrapper"]
+opaque verify (pk : ByteArray) (epoch : UInt32) (message : ByteArray) (signature : ByteArray) : IO Bool
+
+/-- Export a public key handle to serialized bytes. -/
+@[extern "lean_sig_export_public_key_wrapper"]
+opaque exportPublicKey (pk : PublicKey) : IO ByteArray
+
+/-- Serialize a private key to bytes for persistence. -/
+@[extern "lean_sig_serialize_private_key_wrapper"]
+opaque serializePrivateKey (sk : PrivateKey) : IO ByteArray
+
+/-- Deserialize a private key from bytes. -/
+@[extern "lean_sig_deserialize_private_key_wrapper"]
+opaque deserializePrivateKey (data : ByteArray) : IO PrivateKey
+
+/-- Get the prepared epoch interval [start, end) for this private key. -/
+@[extern "lean_sig_get_prepared_interval_wrapper"]
+opaque getPreparedInterval (sk : PrivateKey) : IO (UInt64 × UInt64)
+
+/-- Advance the key's preparation state by one epoch. -/
+@[extern "lean_sig_advance_preparation_wrapper"]
+opaque advancePreparation (sk : PrivateKey) : IO Unit
 
 end LeanConsensus.Crypto.LeanSig

--- a/test/Test/Crypto/LeanSig.lean
+++ b/test/Test/Crypto/LeanSig.lean
@@ -1,0 +1,104 @@
+/-
+  LeanSig FFI Tests — XMSS keygen, sign, verify, serialization
+-/
+
+import LeanConsensus.Crypto.LeanSig
+
+namespace Test.Crypto.LeanSig
+
+open LeanConsensus.Crypto.LeanSig
+
+def check (name : String) (condition : Bool) : IO (Nat × Nat) := do
+  if condition then
+    IO.println s!"  ✓ {name}"
+    return (1, 0)
+  else
+    IO.println s!"  ✗ {name}"
+    return (1, 1)
+
+def checkIO (name : String) (action : IO Bool) : IO (Nat × Nat) := do
+  try
+    let result ← action
+    check name result
+  catch e =>
+    IO.println s!"  ✗ {name} (exception: {e})"
+    return (1, 1)
+
+/-- A dummy 32-byte message for signing. -/
+private def testMessage : ByteArray :=
+  ByteArray.mk (Array.replicate 32 0x42)
+
+/-- A different 32-byte message for tamper tests. -/
+private def tamperedMessage : ByteArray :=
+  ByteArray.mk (Array.replicate 32 0x43)
+
+def runTests : IO (Nat × Nat) := do
+  IO.println "\n── Crypto LeanSig ──"
+  let mut total := 0
+  let mut failures := 0
+
+  -- keygen succeeds
+  let (t, f) ← checkIO "keygen succeeds" do
+    let (_sk, _pk) ← keygen 0 10
+    return true
+  total := total + t; failures := failures + f
+
+  -- exportPublicKey returns non-empty bytes
+  let (t, f) ← checkIO "exportPublicKey returns bytes" do
+    let (_sk, pk) ← keygen 0 10
+    let pkBytes ← exportPublicKey pk
+    return pkBytes.size > 0
+  total := total + t; failures := failures + f
+
+  -- sign produces a signature
+  let (t, f) ← checkIO "sign produces signature" do
+    let (sk, _pk) ← keygen 0 10
+    let sig ← sign sk 0 testMessage
+    return sig.size > 0
+  total := total + t; failures := failures + f
+
+  -- verify valid signature returns true
+  let (t, f) ← checkIO "verify valid signature" do
+    let (sk, pk) ← keygen 0 10
+    let pkBytes ← exportPublicKey pk
+    let sig ← sign sk 0 testMessage
+    verify pkBytes 0 testMessage sig
+  total := total + t; failures := failures + f
+
+  -- verify tampered message returns false
+  let (t, f) ← checkIO "verify tampered message → false" do
+    let (sk, pk) ← keygen 0 10
+    let pkBytes ← exportPublicKey pk
+    let sig ← sign sk 0 testMessage
+    let result ← verify pkBytes 0 tamperedMessage sig
+    return !result
+  total := total + t; failures := failures + f
+
+  -- serializePrivateKey / deserializePrivateKey roundtrip
+  let (t, f) ← checkIO "private key serialize/deserialize roundtrip" do
+    let (sk, pk) ← keygen 0 10
+    let pkBytes ← exportPublicKey pk
+    let skData ← serializePrivateKey sk
+    let sk2 ← deserializePrivateKey skData
+    -- Sign with deserialized key at epoch 0 and verify
+    let sig ← sign sk2 0 testMessage
+    verify pkBytes 0 testMessage sig
+  total := total + t; failures := failures + f
+
+  -- getPreparedInterval returns valid range
+  let (t, f) ← checkIO "getPreparedInterval returns valid range" do
+    let (sk, _pk) ← keygen 0 10
+    let (start, stop) ← getPreparedInterval sk
+    return start ≤ stop
+  total := total + t; failures := failures + f
+
+  -- advancePreparation succeeds
+  let (t, f) ← checkIO "advancePreparation succeeds" do
+    let (sk, _pk) ← keygen 0 10
+    advancePreparation sk
+    return true
+  total := total + t; failures := failures + f
+
+  return (total, failures)
+
+end Test.Crypto.LeanSig

--- a/test/TestMain.lean
+++ b/test/TestMain.lean
@@ -14,6 +14,7 @@ import Test.SSZ.Vector
 import Test.SSZ.Merkleization
 import Test.Consensus.Types
 import Test.Consensus.Signing
+import Test.Crypto.LeanSig
 
 def main : IO Unit := do
   IO.println "═══════════════════════════════════════════"
@@ -57,6 +58,10 @@ def main : IO Unit := do
 
   -- Consensus Signing tests
   let (t, f) ← Test.Consensus.Signing.runTests
+  total := total + t; failures := failures + f
+
+  -- Crypto LeanSig tests
+  let (t, f) ← Test.Crypto.LeanSig.runTests
   total := total + t; failures := failures + f
 
   IO.println "═══════════════════════════════════════════"


### PR DESCRIPTION
## Summary
- Declare opaque handle types (`PrivateKey`, `PublicKey`) using standard Lean 4 FFI pattern
- Add `@[extern]` bindings for all 8 C ABI functions: keygen, sign, verify, exportPublicKey, serializePrivateKey, deserializePrivateKey, getPreparedInterval, advancePreparation
- All operations are `IO` since they call into native XMSS key state

Closes #11

## Test plan
- [x] keygen succeeds
- [x] exportPublicKey returns non-empty bytes
- [x] sign produces a signature
- [x] verify valid signature returns true
- [x] verify tampered message returns false
- [x] Private key serialize/deserialize roundtrip
- [x] getPreparedInterval returns valid range
- [x] advancePreparation succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)