### PR TITLE
feat: prove SSZ roundtrip for Bool and BytesN (#18)

### DIFF
--- a/proofs/SSZ/Roundtrip.lean
+++ b/proofs/SSZ/Roundtrip.lean
@@ -1,9 +1,15 @@
 /-
-  SSZ Roundtrip Theorems — Proof Stubs
+  SSZ Roundtrip Theorems
 
   These theorems express the correctness property that SSZ encoding
-  followed by decoding returns the original value. Currently stubbed
-  with `sorry` — to be proven as the codebase matures.
+  followed by decoding returns the original value.
+
+  Proof status:
+  - Structural invariants (3): proven
+  - Bool roundtrip: proven by case analysis + rfl
+  - UInt64 roundtrip: sorry (requires LE byte reconstruction identity)
+  - BytesN roundtrip: proven via size invariant + proof irrelevance
+  - Container types (4): sorry (derive-generated instances are opaque to simp)
 -/
 
 import LeanConsensus.SSZ
@@ -14,7 +20,9 @@ namespace Proofs.SSZ.Roundtrip
 open LeanConsensus.SSZ
 open LeanConsensus.Consensus
 
+-- ════════════════════════════════════════════════════════════════
 -- Structural properties (trivially provable from structure definitions)
+-- ════════════════════════════════════════════════════════════════
 
 theorem bytesN_size_invariant {n : Nat} (b : BytesN n) : b.data.size = n := b.hsize
 
@@ -22,16 +30,69 @@ theorem sszVector_length_invariant {n : Nat} {α : Type} (v : SszVector n α) : 
 
 theorem sszList_bound_invariant {maxCap : Nat} {α : Type} (l : SszList maxCap α) : l.elems.size ≤ maxCap := l.hbound
 
--- Roundtrip correctness (stubbed)
+-- ════════════════════════════════════════════════════════════════
+-- Bool roundtrip
+-- ════════════════════════════════════════════════════════════════
 
+theorem ssz_roundtrip_bool (v : Bool) :
+    SszDecode.sszDecode (SszEncode.sszEncode v) = .ok v := by
+  cases v <;> rfl
+
+-- ════════════════════════════════════════════════════════════════
+-- UInt64 roundtrip
+-- ════════════════════════════════════════════════════════════════
+
+/- Proof sketch: SszEncode.sszEncode v produces 8 LE bytes via encodeUInt64.
+   SszDecode.sszDecode checks size = 8, then decodeUInt64At reconstructs
+   the value by combining the 8 bytes with shifts.
+
+   The core identity is:
+     let n := v.toNat
+     let b_i := ((n >>> (8*i)) &&& 0xFF).toUInt8
+     (b0.toNat ||| (b1.toNat <<< 8) ||| ... ||| (b7.toNat <<< 56)).toUInt64 = v
+
+   This follows from the bitwise decomposition identity for 64-bit integers.
+   Requires lemmas about BitVec/UInt64 bit manipulation that are non-trivial
+   to establish in Lean 4's current math library. -/
 theorem ssz_roundtrip_uint64 (v : UInt64) :
     SszDecode.sszDecode (SszEncode.sszEncode v) = .ok v := by sorry
 
-theorem ssz_roundtrip_bool (v : Bool) :
-    SszDecode.sszDecode (SszEncode.sszEncode v) = .ok v := by sorry
+-- ════════════════════════════════════════════════════════════════
+-- BytesN roundtrip
+-- ════════════════════════════════════════════════════════════════
 
+/- Proof: sszEncode b = b.data, sszDecode data = BytesN.mkChecked data
+   which checks data.size = n. Since b.hsize : b.data.size = n,
+   the check passes and we get ⟨b.data, proof⟩.
+   Equality with b follows from proof irrelevance on hsize. -/
 theorem ssz_roundtrip_bytesN {n : Nat} (b : BytesN n) :
-    SszDecode.sszDecode (SszEncode.sszEncode b) = .ok b := by sorry
+    SszDecode.sszDecode (SszEncode.sszEncode b) = .ok b := by
+  simp [SszEncode.sszEncode, SszDecode.sszDecode, BytesN.mkChecked, b.hsize]
+
+-- ════════════════════════════════════════════════════════════════
+-- Container roundtrip proofs
+-- ════════════════════════════════════════════════════════════════
+
+/- Container proofs are structurally similar but rely on unfolding
+   derive-generated SszEncode/SszDecode instances. The derive handlers
+   generate code using SszEncoder (two-pass) and SszDecoder (Except.bind
+   chains), which produce large terms that simp struggles with.
+
+   Each proof would need to:
+   1. Show SszEncoder.finalize produces the correct byte layout
+   2. Show SszDecoder reads back each field correctly
+   3. Compose field-level roundtrip proofs
+
+   For all-fixed containers like Checkpoint (8 + 32 = 40 bytes),
+   the encode is a simple concatenation and decode slices at
+   known offsets. The proof reduces to:
+   - Showing extract boundaries are correct
+   - Applying field-level roundtrip proofs (UInt64, BytesN)
+   - Showing struct equality from field equality
+
+   The key blocker is that UInt64 roundtrip (ssz_roundtrip_uint64)
+   remains unproven, so even if the container plumbing is verified,
+   the Slot/ValidatorIndex fields would need sorry. -/
 
 theorem ssz_roundtrip_checkpoint (c : Checkpoint) :
     SszDecode.sszDecode (SszEncode.sszEncode c) = .ok c := by sorry


### PR DESCRIPTION
## Summary
- Prove 2 of 7 sorry'd SSZ roundtrip theorems (down from 7 to 5 sorrys)
- `ssz_roundtrip_bool`: proven by case analysis + `rfl`
- `ssz_roundtrip_bytesN`: proven via size invariant + proof irrelevance
- Remaining 5 sorrys with documented proof sketches:
  - UInt64: requires LE byte reconstruction identity (bitwise algebra)
  - Container types (4): blocked on UInt64 + derive-generated instance unfoldability

## Test plan
- [x] `lake build Proofs` compiles with zero errors
- [x] `ssz_roundtrip_bool` — no sorry
- [x] `ssz_roundtrip_bytesN` — no sorry
- [x] Remaining sorrys produce warnings (expected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)