### PR TITLE
feat: add consensus safety theorems with supermajority proof (#19)

### DIFF
--- a/proofs/Consensus/Safety.lean
+++ b/proofs/Consensus/Safety.lean
@@ -1,19 +1,124 @@
 /-
-  Consensus Safety Theorems — Proof Stubs
+  Consensus Safety Theorems
 
   Key safety invariants of the 3-Slot Finality consensus protocol.
-  Long-term verification targets.
+  These theorems express properties about the fork choice and finalization
+  that are essential for protocol correctness.
+
+  Proof status:
+  - supermajority_intersection: proven (pure arithmetic)
+  - no_surpassing_finalization: sorry (structural, requires trace analysis)
+  - finality_safety: sorry (core safety, requires trace model)
 -/
 
-import LeanConsensus.Consensus.Types
+import LeanConsensus.Consensus.ForkChoice
+import LeanConsensus.Consensus.StateTransition
 
 namespace Proofs.Consensus.Safety
 
 open LeanConsensus.SSZ
 open LeanConsensus.Consensus
+open LeanConsensus.Consensus.ForkChoice
+open LeanConsensus.Consensus.StateTransition
 
--- Placeholder: the real finality safety theorem needs
--- finalization predicates from Phase 3.
-theorem finality_placeholder : True := by trivial
+-- ════════════════════════════════════════════════════════════════
+-- Definitions
+-- ════════════════════════════════════════════════════════════════
+
+/-- Ancestry predicate: `ancestor` is reachable from `descendant`
+    by following the parent chain in the store. -/
+def IsAncestor (store : Store) (ancestor descendant : Root) : Prop :=
+  isAncestor store ancestor descendant = true
+
+/-- Supermajority support: more than 2/3 of total weight supports a checkpoint. -/
+def HasSupermajority (totalBalance supportingBalance : Nat) : Prop :=
+  supportingBalance * FINALITY_THRESHOLD_DENOMINATOR ≥
+    totalBalance * FINALITY_THRESHOLD_NUMERATOR
+
+-- ════════════════════════════════════════════════════════════════
+-- Theorem 1: Supermajority Intersection
+-- ════════════════════════════════════════════════════════════════
+
+/-- Two supermajority sets must overlap.
+
+    If set A has more than 2/3 of total weight and set B has more than
+    2/3 of total weight, then A ∩ B has more than 1/3 of total weight.
+
+    This is the fundamental lemma behind consensus safety: if two
+    conflicting checkpoints both have supermajority support, at least
+    1/3 of validators must have voted for both (equivocation). -/
+theorem supermajority_intersection
+    (total a b overlap : Nat)
+    (hTotal : total > 0)
+    (hA : a * FINALITY_THRESHOLD_DENOMINATOR ≥ total * FINALITY_THRESHOLD_NUMERATOR)
+    (hB : b * FINALITY_THRESHOLD_DENOMINATOR ≥ total * FINALITY_THRESHOLD_NUMERATOR)
+    (hAB : a + b ≤ total + overlap)
+    : overlap * FINALITY_THRESHOLD_DENOMINATOR ≥ total := by
+  -- a * 3 ≥ total * 2 and b * 3 ≥ total * 2
+  -- So a ≥ 2*total/3 and b ≥ 2*total/3
+  -- a + b ≥ 4*total/3
+  -- Since a + b ≤ total + overlap: overlap ≥ a + b - total ≥ total/3
+  -- overlap * 3 ≥ total
+  simp [FINALITY_THRESHOLD_DENOMINATOR, FINALITY_THRESHOLD_NUMERATOR] at *
+  omega
+
+-- ════════════════════════════════════════════════════════════════
+-- Theorem 2: No Surpassing Finalization
+-- ════════════════════════════════════════════════════════════════
+
+/-- After processing a block via onBlock, the finalized checkpoint slot
+    never decreases.
+
+    Proof sketch: updateCheckpoints only updates finalizedCheckpoint when
+    the new justified checkpoint is sufficiently ahead of the current
+    finalized checkpoint. The new finalized checkpoint is set to the
+    PREVIOUS justified checkpoint, which was already at or ahead of the
+    current finalized. Since checkpoint slots are monotonically
+    non-decreasing through justification, finalized slots also never
+    decrease.
+
+    The key invariant is: finalizedCheckpoint.slot ≤ justifiedCheckpoint.slot
+    which is maintained by updateCheckpoints. -/
+theorem no_surpassing_finalization
+    (store : Store) (block : BeaconBlock) (store' : Store)
+    (hOk : onBlock store block = .ok store')
+    : store'.finalizedCheckpoint.slot ≥ store.finalizedCheckpoint.slot := by
+  sorry
+
+-- ════════════════════════════════════════════════════════════════
+-- Theorem 3: Finality Safety
+-- ════════════════════════════════════════════════════════════════
+
+/-- Core safety property: if two checkpoints are both finalized,
+    one must be an ancestor of the other.
+
+    Proof sketch: Finalization requires two consecutive supermajority
+    attestations. By supermajority_intersection, any two supermajority
+    sets overlap by at least 1/3. If two conflicting checkpoints were
+    both finalized (neither is an ancestor of the other), then:
+
+    1. Both have supermajority support at their respective slots
+    2. By intersection, some validators support both
+    3. These validators must have equivocated (attested to conflicting
+       checkpoints at the same slot)
+    4. Under the assumption that < 1/3 of validators equivocate,
+       this is a contradiction
+
+    Formalizing this requires:
+    - A trace model capturing the sequence of onBlock/onAttestation calls
+    - An equivocation bound assumption (< 1/3 of total stake)
+    - Showing that the checkpoint ancestry relation is a total order
+      on the finalized chain
+
+    This is left as sorry with the proof structure outlined above. -/
+theorem finality_safety
+    (store : Store)
+    (cp1 cp2 : Checkpoint)
+    (hFin1 : cp1.slot ≤ store.finalizedCheckpoint.slot)
+    (hFin2 : cp2.slot ≤ store.finalizedCheckpoint.slot)
+    (hStore1 : store.blocks.contains cp1.root)
+    (hStore2 : store.blocks.contains cp2.root)
+    : IsAncestor store cp1.root cp2.root ∨ IsAncestor store cp2.root cp1.root := by
+  sorry
 
 end Proofs.Consensus.Safety


### PR DESCRIPTION
## Summary
- Add formal safety properties for 3-Slot Finality consensus (depends on #17)
- `IsAncestor` / `HasSupermajority`: formal predicates for ancestry and support
- `supermajority_intersection`: **proven** — two 2/3+ sets overlap by 1/3+ (omega)
- `no_surpassing_finalization`: sorry — finalized slot never decreases
- `finality_safety`: sorry — finalized checkpoints form a chain
- Detailed proof sketches documenting the approach for remaining sorrys

## Test plan
- [x] `lake build Proofs` compiles with zero errors
- [x] `supermajority_intersection` — fully proven, no sorry
- [x] Remaining 2 sorrys produce warnings (expected)
- [x] `lake exe test-runner` — all 116 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)