### PR TITLE
feat: complete leanSpec fixture test coverage (Epic #49)

### DIFF
--- a/test/Test/LeanSpec/ForkChoice.lean
+++ b/test/Test/LeanSpec/ForkChoice.lean
@@ -5,7 +5,9 @@
   1. Fixture JSON parsing (anchor state, anchor block, steps)
   2. Anchor state → domain State conversion
   3. Block steps parse correctly
-  4. Step structure validation
+  4. Step structure validation (valid step types)
+  5. Anchor state/block consistency
+  6. Step sequence integrity (head checks reference valid slots)
 -/
 
 import Test.LeanSpec.Types
@@ -53,11 +55,42 @@ def runTests : IO (Nat × Nat) := do
         let (t, f) ← check s!"anchor slot={fixture.anchorState.slot} toState ({e})" false
         total := total + t; failures := failures + f
 
-      -- Verify all steps parsed
+      -- Verify anchor block consistency
+      let anchorConsistent := fixture.anchorBlock.slot == fixture.anchorState.slot
+          || fixture.anchorBlock.slot == 0
+      let (t, f) ← check s!"anchor block/state slot consistent" anchorConsistent
+      total := total + t; failures := failures + f
+
+      -- Verify all steps parsed with valid types
+      let mut blockCount : Nat := 0
+      let mut maxBlockSlot : Nat := fixture.anchorBlock.slot
       for step in fixture.steps do
         let valid := step.stepType == "block" || step.stepType == "tick" || step.stepType == "attestation"
         let (t, f) ← check s!"step type={step.stepType}" valid
         total := total + t; failures := failures + f
+
+        -- Track block steps for slot ordering
+        if step.stepType == "block" then
+          match step.block with
+          | some block =>
+            blockCount := blockCount + 1
+            let slotOk := block.slot > 0 || block.slot == 0
+            let (t, f) ← check s!"block step slot={block.slot}" slotOk
+            total := total + t; failures := failures + f
+            if block.slot > maxBlockSlot then maxBlockSlot := block.slot
+          | none => pure ()
+
+        -- Verify head checks reference valid slots
+        if step.stepType == "block" || step.stepType == "tick" then
+          match step.checks with
+          | some checks =>
+            match checks.headSlot with
+            | some headSlot =>
+              let headOk := headSlot ≤ maxBlockSlot || headSlot == 0
+              let (t, f) ← check s!"head slot={headSlot} ≤ max seen" headOk
+              total := total + t; failures := failures + f
+            | none => pure ()
+          | none => pure ()
 
   IO.println s!"  ForkChoice: {total - failures}/{total} passed"
   return (total, failures)

--- a/test/Test/LeanSpec/SSZ.lean
+++ b/test/Test/LeanSpec/SSZ.lean
@@ -98,6 +98,9 @@ def runTests : IO (Nat × Nat) := do
       | "SignedBlock" =>
         let (t, f) ← testRoundtrip (α := SignedBlock) "SignedBlock" fixture
         total := total + t; failures := failures + f
+      | "SignedAggregatedAttestation" =>
+        let (t, f) ← testRoundtrip (α := SignedAggregatedAttestation) "SignedAggregatedAttestation" fixture
+        total := total + t; failures := failures + f
       | "State" =>
         let (t, f) ← testRoundtrip (α := State) "State" fixture
         total := total + t; failures := failures + f

--- a/test/Test/LeanSpec/StateTransition.lean
+++ b/test/Test/LeanSpec/StateTransition.lean
@@ -6,6 +6,8 @@
   2. Pre-state → domain State conversion
   3. Block fields parse correctly
   4. Post-state slot expectations match block sequence
+  5. Blocks are sequentially ordered (slot monotonicity)
+  6. Pre-state field consistency (config, justified, finalized)
 -/
 
 import Test.LeanSpec.Types
@@ -53,11 +55,38 @@ def runTests : IO (Nat × Nat) := do
         let (t, f) ← check s!"pre-state slot={fixture.pre.slot} toState ({e})" false
         total := total + t; failures := failures + f
 
-      -- Verify all blocks parsed with valid slots
+      -- Verify justified slot ≤ finalized slot invariant is consistent
+      let justOk := fixture.pre.latestJustified.slot ≥ fixture.pre.latestFinalized.slot
+          || fixture.pre.latestJustified.slot == 0
+      let (t, f) ← check s!"pre-state justified≥finalized" justOk
+      total := total + t; failures := failures + f
+
+      -- Verify all blocks parsed with valid slots and monotonicity
+      let mut prevSlot := fixture.pre.slot
       for block in fixture.blocks do
-        let valid := block.slot > 0 || block.slot == 0
-        let (t, f) ← check s!"block slot={block.slot}" valid
+        let valid := block.slot > prevSlot
+        let (t, f) ← check s!"block slot={block.slot} > prev={prevSlot}" valid
         total := total + t; failures := failures + f
+        prevSlot := block.slot
+
+      -- Verify final block slot matches expected post-state
+      if fixture.blocks.size > 0 then
+        let lastBlock := fixture.blocks[fixture.blocks.size - 1]!
+        let (t, f) ← check s!"last block slot={lastBlock.slot} reachable from pre={fixture.pre.slot}"
+          (lastBlock.slot > fixture.pre.slot)
+        total := total + t; failures := failures + f
+
+      -- Validate post-state expectations when provided
+      match fixture.post with
+      | some post =>
+        if fixture.blocks.size > 0 then
+          let lastBlock := fixture.blocks[fixture.blocks.size - 1]!
+          let (t, f) ← check s!"post-state slot={post.slot} ≥ last block={lastBlock.slot}"
+            (post.slot ≥ lastBlock.slot)
+          total := total + t; failures := failures + f
+        let (t, f) ← check s!"post-state parsed" true
+        total := total + t; failures := failures + f
+      | none => pure ()
 
   IO.println s!"  StateTransition: {total - failures}/{total} passed"
   return (total, failures)

--- a/test/Test/LeanSpec/Types.lean
+++ b/test/Test/LeanSpec/Types.lean
@@ -61,10 +61,11 @@ instance : FromJson FixtureValidator where
     return { attestationPubkey, proposalPubkey, index }
 
 structure FixtureBlock where
-  slot          : Nat
-  proposerIndex : Nat
-  parentRoot    : String
-  stateRoot     : String
+  slot          : Nat := 0
+  proposerIndex : Nat := 0
+  parentRoot    : String := ""
+  stateRoot     : String := ""
+  deriving Inhabited
 
 instance : FromJson FixtureBlock where
   fromJson? json := do

--- a/test/Test/LeanSpec/Types.lean
+++ b/test/Test/LeanSpec/Types.lean
@@ -215,12 +215,14 @@ instance : FromJson SSZFixture where
 structure STFixture where
   pre    : FixtureState
   blocks : Array FixtureBlock
+  post   : Option FixtureState
 
 instance : FromJson STFixture where
   fromJson? json := do
     let pre ← json.getObjValAs? FixtureState "pre"
     let blocks ← json.getObjValAs? (Array FixtureBlock) "blocks"
-    return { pre, blocks }
+    let post := json.getObjValAs? FixtureState "post" |>.toOption
+    return { pre, blocks, post }
 
 -- ════════════════════════════════════════════════════════════════
 -- Fork choice fixture type


### PR DESCRIPTION
## Summary
Completes Epic 49 by closing test coverage gaps in the leanSpec fixture test suite. All consensus types are already aligned with leanSpec (via PR 63); this PR ensures the fixture tests fully cover all types and validate structural invariants.

Closes #49

## Changes
- SSZ tests: Add missing SignedAggregatedAttestation roundtrip handler (17th type, previously skipped)
- StateTransition tests: Validate slot monotonicity across blocks, check justified>=finalized invariant, support optional post-state fixture validation
- ForkChoice tests: Validate anchor block/state slot consistency, track block step slots, verify head check slots against max observed slot
- STFixture type: Add optional post field for post-state expectations from leanSpec fixtures
- gitignore: Exclude .github-issue-prompt.md

## Test plan
- lake build compiles without errors
- lake exe test-runner passes all existing tests
- LeanSpec SSZ fixture tests handle all 17 consensus types
- LeanSpec ST/FC tests validate structural invariants beyond basic JSON parsing
