### PR TITLE
refactor(leanSpec): align constants with leanSpec

### DIFF
--- a/LeanConsensus/Consensus/Constants.lean
+++ b/LeanConsensus/Consensus/Constants.lean
@@ -2,7 +2,8 @@
   Consensus Constants — pq-devnet-3
 
   These constants define the consensus parameters for the post-quantum
-  devnet with 3-Slot Finality. Values are from the devnet-3 spec.
+  devnet with 3-Slot Finality. Values are aligned with
+  leanSpec/src/lean_spec/subspecs/chain/config.py.
 
   All constants are Nat-level (not UInt64) so they can be used as
   type-level parameters for SszVector and SszList bounds.


### PR DESCRIPTION
## Summary
- Verified all constants in Constants.lean already match leanSpec values (aligned in Epic #49, commit b530523)
- Confirmed no stale references to removed constants

Closes #50

## Changes
All changes were already applied in the Epic #49 PR (#63). This PR verifies the acceptance criteria:

| Constant | Value | Status |
|---|---|---|
| XMSS_PUBKEY_SIZE | 52 | Correct |
| VALIDATOR_REGISTRY_LIMIT | 4096 | Correct |
| HISTORICAL_ROOTS_LIMIT | 262144 | Correct |
| SLOTS_PER_HISTORICAL_ROOT | removed | Correct |
| MAX_VALIDATORS_PER_SUBNET | removed | Correct |
| MAX_ATTESTATIONS | 4096 | Correct |
| MAX_ATTESTATIONS_STATE | removed | Correct |
| INTERVALS_PER_SLOT | 5 | Correct |
| JUSTIFICATION_LOOKBACK_SLOTS | 3 | Correct |

## Test plan
- Grep confirms no references to removed constants
- All constant values match leanSpec config.py
- lake build compiles successfully
