### PR TITLE
test: add Config SSZ roundtrip tests

### DIFF
--- a/test/Test/SSZ/Roundtrip.lean
+++ b/test/Test/SSZ/Roundtrip.lean
@@ -45,6 +45,14 @@ def runTests : IO (Nat × Nat) := do
   let (t, f) ← check "Bytes32 zero roundtrip" (roundtrip Bytes32.zero)
   total := total + t; failures := failures + f
 
+  let cfg : Config := { genesisTime := 1700000000 }
+  let (t, f) ← check "Config roundtrip" (roundtrip cfg)
+  total := total + t; failures := failures + f
+
+  let cfgZero : Config := { genesisTime := 0 }
+  let (t, f) ← check "Config zero roundtrip" (roundtrip cfgZero)
+  total := total + t; failures := failures + f
+
   let cp : Checkpoint := { root := Bytes32.zero, slot := 100 }
   let (t, f) ← check "Checkpoint roundtrip" (roundtrip cp)
   total := total + t; failures := failures + f


### PR DESCRIPTION
## Summary
- Add Config SSZ encode/decode roundtrip tests to verify the Config container serialization correctness
- Tests cover both non-zero (`genesisTime := 1700000000`) and zero (`genesisTime := 0`) values

Closes #51

## Changes
- `test/Test/SSZ/Roundtrip.lean`: Added two Config roundtrip test cases following existing test patterns

## Test plan
- `lake exe test-runner` — verify Config roundtrip tests pass alongside existing SSZ tests
- LeanSpec SSZ fixture tests already cover Config via `test/Test/LeanSpec/SSZ.lean`

🤖 Generated with [Claude Code](https://claude.com/claude-code)