### PR TITLE
fix: align Checkpoint SSZ field order (root, slot)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ ffi/*.a
 ffi/lean_sig_ffi/target/
 ffi/lean_sig_ffi/Cargo.lock
 ffi/lean_multisig_ffi/target/
+.github-issue-prompt.md

--- a/test/Test/Consensus/Signing.lean
+++ b/test/Test/Consensus/Signing.lean
@@ -80,7 +80,7 @@ def runTests : IO (Nat × Nat) := do
   total := total + t; failures := failures + f
 
   -- computeSigningRoot produces a 32-byte result
-  let cp : Checkpoint := { slot := 42, root := Bytes32.zero }
+  let cp : Checkpoint := { root := Bytes32.zero, slot := 42 }
   let sigRoot := computeSigningRoot cp domain
   let (t, f) ← check "computeSigningRoot produces Bytes32" (sigRoot.data.size == 32)
   total := total + t; failures := failures + f
@@ -91,7 +91,7 @@ def runTests : IO (Nat × Nat) := do
   total := total + t; failures := failures + f
 
   -- Different objects produce different signing roots
-  let cp2 : Checkpoint := { slot := 43, root := Bytes32.zero }
+  let cp2 : Checkpoint := { root := Bytes32.zero, slot := 43 }
   let sigRoot3 := computeSigningRoot cp2 domain
   let (t, f) ← check "different objects → different signing roots" (!(sigRoot == sigRoot3))
   total := total + t; failures := failures + f


### PR DESCRIPTION
## Summary
- Fix remaining Checkpoint construction sites in signing tests to use root before slot field order, matching the leanSpec-aligned structure definition

Closes #52

## Changes
- test/Test/Consensus/Signing.lean: Reorder Checkpoint field construction from { slot, root } to { root, slot } in 2 test sites
- .gitignore: Add .github-issue-prompt.md

The Checkpoint structure definition was already aligned to leanSpec order (root before slot) in the Epic 49 commit (b530523). This PR fixes the remaining test construction sites that still used the old slot, root field order for consistency.

## Test plan
- lake build compiles without errors
- lake exe test-runner passes all tests (named fields are order-independent in Lean 4, so behavior is unchanged)
- Verify Checkpoint SSZ layout encodes root (32 bytes) before slot (8 bytes)
