### PR TITLE
refactor: replace Validator type with 3-field leanSpec model

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ ffi/*.a
 ffi/lean_sig_ffi/target/
 ffi/lean_sig_ffi/Cargo.lock
 ffi/lean_multisig_ffi/target/
+.github-issue-prompt.md

--- a/LeanConsensus/Consensus/Constants.lean
+++ b/LeanConsensus/Consensus/Constants.lean
@@ -49,9 +49,6 @@ def FINALITY_THRESHOLD_NUMERATOR : Nat := 2
 /-- Denominator of the finality threshold. -/
 def FINALITY_THRESHOLD_DENOMINATOR : Nat := 3
 
-/-- Sentinel slot value representing "no exit scheduled". -/
-def FAR_FUTURE_SLOT : Nat := 0xFFFFFFFFFFFFFFFF
-
 -- ════════════════════════════════════════════════════════════════
 -- Cryptographic Sizes
 -- ════════════════════════════════════════════════════════════════

--- a/LeanConsensus/Genesis.lean
+++ b/LeanConsensus/Genesis.lean
@@ -23,10 +23,9 @@ open Lean (Json FromJson ToJson)
 
 /-- Chain-level genesis parameters. -/
 structure GenesisConfig where
-  genesisTime         : Nat
-  forkVersion         : String
-  validatorCount      : Nat
-  balancePerValidator : Nat
+  genesisTime    : Nat
+  forkVersion    : String
+  validatorCount : Nat
   deriving Inhabited
 
 instance : FromJson GenesisConfig where
@@ -34,33 +33,31 @@ instance : FromJson GenesisConfig where
     let genesisTime ← json.getObjValAs? Nat "genesis_time"
     let forkVersion ← json.getObjValAs? String "fork_version"
     let validatorCount ← json.getObjValAs? Nat "validator_count"
-    let balancePerValidator ← json.getObjValAs? Nat "balance_per_validator"
-    return { genesisTime, forkVersion, validatorCount, balancePerValidator }
+    return { genesisTime, forkVersion, validatorCount }
 
 instance : ToJson GenesisConfig where
   toJson c := Json.mkObj [
     ("genesis_time", ToJson.toJson c.genesisTime),
     ("fork_version", ToJson.toJson c.forkVersion),
-    ("validator_count", ToJson.toJson c.validatorCount),
-    ("balance_per_validator", ToJson.toJson c.balancePerValidator)
+    ("validator_count", ToJson.toJson c.validatorCount)
   ]
 
-/-- A single validator deposit entry. -/
+/-- A single validator deposit entry with dual XMSS keys. -/
 structure ValidatorDeposit where
-  pubkey  : String
-  balance : Nat
+  attestationPubkey : String
+  proposalPubkey    : String
   deriving Inhabited
 
 instance : FromJson ValidatorDeposit where
   fromJson? json := do
-    let pubkey ← json.getObjValAs? String "pubkey"
-    let balance ← json.getObjValAs? Nat "balance"
-    return { pubkey, balance }
+    let attestationPubkey ← json.getObjValAs? String "attestation_pubkey"
+    let proposalPubkey ← json.getObjValAs? String "proposal_pubkey"
+    return { attestationPubkey, proposalPubkey }
 
 instance : ToJson ValidatorDeposit where
   toJson d := Json.mkObj [
-    ("pubkey", ToJson.toJson d.pubkey),
-    ("balance", ToJson.toJson d.balance)
+    ("attestation_pubkey", ToJson.toJson d.attestationPubkey),
+    ("proposal_pubkey", ToJson.toJson d.proposalPubkey)
   ]
 
 /-- Complete genesis file with config and validator list. -/
@@ -99,10 +96,31 @@ def loadGenesisFile (path : System.FilePath) : IO GenesisFile := do
 -- Genesis State Construction
 -- ════════════════════════════════════════════════════════════════
 
+/-- Parse a hex string (with optional 0x prefix) into a BytesN, zero-filling on failure. -/
+private def hexToBytesN (n : Nat) (hex : String) : BytesN n :=
+  let s := if hex.startsWith "0x" then String.ofList (hex.toList.drop 2) else hex
+  let chars := s.toList
+  let raw := Id.run do
+    let mut result := ByteArray.empty
+    let mut i := 0
+    while h : i + 1 < chars.length do
+      let hi := hexDigitVal (chars[i]'(by omega))
+      let lo := hexDigitVal (chars[i + 1]'(by omega))
+      result := result.push (hi * 16 + lo)
+      i := i + 2
+    return result
+  if h : raw.size = n then ⟨raw, h⟩ else BytesN.zero n
+where
+  hexDigitVal (c : Char) : UInt8 :=
+    if '0' ≤ c && c ≤ '9' then (c.toNat - '0'.toNat).toUInt8
+    else if 'a' ≤ c && c ≤ 'f' then (c.toNat - 'a'.toNat + 10).toUInt8
+    else if 'A' ≤ c && c ≤ 'F' then (c.toNat - 'A'.toNat + 10).toUInt8
+    else 0
+
 /-- Build a Validator from deposit data. -/
-private def buildValidator (_deposit : ValidatorDeposit) (idx : Nat) : Validator :=
-  { attestationPubkey := BytesN.zero XMSS_PUBKEY_SIZE
-    proposalPubkey := BytesN.zero XMSS_PUBKEY_SIZE
+private def buildValidator (deposit : ValidatorDeposit) (idx : Nat) : Validator :=
+  { attestationPubkey := hexToBytesN XMSS_PUBKEY_SIZE deposit.attestationPubkey
+    proposalPubkey := hexToBytesN XMSS_PUBKEY_SIZE deposit.proposalPubkey
     index := idx.toUInt64 }
 
 /-- Build the genesis State from a GenesisFile.

--- a/docs/integration.md
+++ b/docs/integration.md
@@ -1,6 +1,6 @@
 ---
 title: Integration Guide
-last_updated: 2026-03-18
+last_updated: 2026-03-21
 tags:
   - integration
   - devnet
@@ -36,14 +36,13 @@ Create a `genesis.json` matching the devnet genesis state:
   "config": {
     "genesis_time": 1700000000,
     "fork_version": "0x10000091",
-    "validator_count": 4,
-    "balance_per_validator": 32000000000
+    "validator_count": 4
   },
   "validators": [
-    { "pubkey": "0x...", "balance": 32000000000 },
-    { "pubkey": "0x...", "balance": 32000000000 },
-    { "pubkey": "0x...", "balance": 32000000000 },
-    { "pubkey": "0x...", "balance": 32000000000 }
+    { "attestation_pubkey": "0x...", "proposal_pubkey": "0x..." },
+    { "attestation_pubkey": "0x...", "proposal_pubkey": "0x..." },
+    { "attestation_pubkey": "0x...", "proposal_pubkey": "0x..." },
+    { "attestation_pubkey": "0x...", "proposal_pubkey": "0x..." }
   ]
 }
 ```

--- a/test/Test/Genesis.lean
+++ b/test/Test/Genesis.lean
@@ -29,7 +29,6 @@ def runTests : IO (Nat × Nat) := do
     genesisTime := 1700000000
     forkVersion := "0x00000001"
     validatorCount := 4
-    balancePerValidator := 32000000000
   }
   let json := ToJson.toJson config
   match @FromJson.fromJson? GenesisConfig _ json with
@@ -42,12 +41,15 @@ def runTests : IO (Nat × Nat) := do
     total := total + t; failures := failures + f
 
   -- ValidatorDeposit JSON roundtrip
-  let deposit : ValidatorDeposit := { pubkey := "0xaabb", balance := 32000000000 }
+  let deposit : ValidatorDeposit := {
+    attestationPubkey := "0xaabb"
+    proposalPubkey := "0xccdd"
+  }
   let json := ToJson.toJson deposit
   match @FromJson.fromJson? ValidatorDeposit _ json with
   | .ok d' =>
     let (t, f) ← check "ValidatorDeposit JSON roundtrip"
-      (d'.pubkey == "0xaabb" && d'.balance == 32000000000)
+      (d'.attestationPubkey == "0xaabb" && d'.proposalPubkey == "0xccdd")
     total := total + t; failures := failures + f
   | .error e =>
     let (t, f) ← check s!"ValidatorDeposit JSON roundtrip (error: {e})" false
@@ -55,13 +57,12 @@ def runTests : IO (Nat × Nat) := do
 
   -- Build genesis state with small validator set
   let genesis : GenesisFile := {
-    config := { genesisTime := 0, forkVersion := "0x00", validatorCount := 4,
-                balancePerValidator := 32000000000 }
+    config := { genesisTime := 0, forkVersion := "0x00", validatorCount := 4 }
     validators := #[
-      { pubkey := "0x01", balance := 32000000000 },
-      { pubkey := "0x02", balance := 32000000000 },
-      { pubkey := "0x03", balance := 32000000000 },
-      { pubkey := "0x04", balance := 32000000000 }
+      { attestationPubkey := "0x01", proposalPubkey := "0x02" },
+      { attestationPubkey := "0x03", proposalPubkey := "0x04" },
+      { attestationPubkey := "0x05", proposalPubkey := "0x06" },
+      { attestationPubkey := "0x07", proposalPubkey := "0x08" }
     ]
   }
   match buildGenesisState genesis with


### PR DESCRIPTION
## Summary
- Remove vestiges of the old 6-field Validator model from Genesis and Constants
- Align `ValidatorDeposit` with dual XMSS keys (`attestationPubkey`, `proposalPubkey`)
- Remove dead `FAR_FUTURE_SLOT` constant and unused `balancePerValidator` field

Closes #53

## Changes
- **Constants.lean**: Remove `FAR_FUTURE_SLOT` (dead code from old validator lifecycle)
- **Genesis.lean**: Replace `ValidatorDeposit` single `pubkey`+`balance` with dual XMSS keys; remove `balancePerValidator` from `GenesisConfig`; add `hexToBytesN` helper; update `buildValidator` to parse deposit hex keys
- **test/Test/Genesis.lean**: Update test fixtures to use dual-key deposit format
- **docs/integration.md**: Update genesis JSON example to reflect new schema

## Test plan
- [ ] `lake build` compiles without errors
- [ ] `lake exe test-runner` passes all tests including Genesis tests
- [ ] LeanSpec SSZ fixtures for Validator type pass roundtrip

🤖 Generated with [Claude Code](https://claude.com/claude-code)