### PR TITLE
refactor: AttestationData head:Checkpoint + field reorder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ ffi/*.a
 ffi/lean_sig_ffi/target/
 ffi/lean_sig_ffi/Cargo.lock
 ffi/lean_multisig_ffi/target/
+.github-issue-prompt.md


### PR DESCRIPTION
## Summary
- Confirms AttestationData already matches leanSpec after Epic 49 (b530523)
- headRoot: Root changed to head: Checkpoint (type change adding slot)
- sourceCheckpoint renamed to source, targetCheckpoint renamed to target
- Field order: target before source
- SSZ fixed size: 128 bytes (slot:8 + head:40 + target:40 + source:40)

Closes #54

## Changes
- .gitignore: exclude .github-issue-prompt.md
- No code changes needed: all AttestationData refactoring was completed in the Epic 49 commit (b530523)

## Test plan
- [x] AttestationData encode size = 128 test
- [x] AttestationData roundtrip test
- [x] AttestationData SSZ fixture roundtrip
- [x] All downstream consumers use correct field names
