### PR TITLE
refactor(leanSpec): add AggregationBits and AggregatedSignatureProof

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ ffi/*.a
 ffi/lean_sig_ffi/target/
 ffi/lean_sig_ffi/Cargo.lock
 ffi/lean_multisig_ffi/target/
+.github-issue-prompt.md

--- a/test/Test/SSZ/Roundtrip.lean
+++ b/test/Test/SSZ/Roundtrip.lean
@@ -73,6 +73,20 @@ def runTests : IO (Nat × Nat) := do
   let (t, f) ← check "Validator roundtrip" (roundtrip val)
   total := total + t; failures := failures + f
 
+  let aspEmpty : AggregatedSignatureProof := {
+    participants := Bitlist.empty VALIDATOR_REGISTRY_LIMIT
+    proofData := ⟨ByteArray.empty, by decide⟩
+  }
+  let (t, f) ← check "AggregatedSignatureProof empty roundtrip" (roundtrip aspEmpty)
+  total := total + t; failures := failures + f
+
+  let aspWithData : AggregatedSignatureProof := {
+    participants := Bitlist.empty VALIDATOR_REGISTRY_LIMIT
+    proofData := ⟨ByteArray.mk #[0xDE, 0xAD, 0xBE, 0xEF], by decide⟩
+  }
+  let (t, f) ← check "AggregatedSignatureProof with data roundtrip" (roundtrip aspWithData)
+  total := total + t; failures := failures + f
+
   return (total, failures)
 
 end Test.SSZ.Roundtrip


### PR DESCRIPTION
## Summary
- AggregationBits and AggregatedSignatureProof types already landed in PR 63
- Adds SSZ roundtrip unit tests for AggregatedSignatureProof to satisfy acceptance criteria

Closes #55

## Changes
- test/Test/SSZ/Roundtrip.lean: add two AggregatedSignatureProof roundtrip tests (empty and with proof data)
- .gitignore: ignore .github-issue-prompt.md

## Test plan
- [ ] lake build compiles successfully
- [ ] lake exe test-runner passes all roundtrip tests including the new AggregatedSignatureProof cases
