### PR TITLE
test: add SSZ roundtrip tests for split attestation types

### DIFF
--- a/test/Test/LeanSpec/SSZ.lean
+++ b/test/Test/LeanSpec/SSZ.lean
@@ -80,6 +80,9 @@ def runTests : IO (Nat × Nat) := do
       | "AggregatedAttestation" =>
         let (t, f) ← testRoundtrip (α := AggregatedAttestation) "AggregatedAttestation" fixture
         total := total + t; failures := failures + f
+      | "SignedAggregatedAttestation" =>
+        let (t, f) ← testRoundtrip (α := SignedAggregatedAttestation) "SignedAggregatedAttestation" fixture
+        total := total + t; failures := failures + f
       | "Attestation" =>
         let (t, f) ← testRoundtrip (α := Attestation) "Attestation" fixture
         total := total + t; failures := failures + f

--- a/test/Test/SSZ/Roundtrip.lean
+++ b/test/Test/SSZ/Roundtrip.lean
@@ -95,7 +95,7 @@ def runTests : IO (Nat × Nat) := do
   let (t, f) ← check "AggregatedSignatureProof with data roundtrip" (roundtrip aspWithData)
   total := total + t; failures := failures + f
 
-  let aggBits := Bitlist.zeros 4 (by omega : 4 ≤ VALIDATOR_REGISTRY_LIMIT)
+  let aggBits := Bitlist.zeros 4 (by native_decide : 4 ≤ VALIDATOR_REGISTRY_LIMIT)
   let aggAtt : AggregatedAttestation := {
     aggregationBits := aggBits
     data := ad
@@ -103,7 +103,7 @@ def runTests : IO (Nat × Nat) := do
   let (t, f) ← check "AggregatedAttestation roundtrip" (roundtrip aggAtt)
   total := total + t; failures := failures + f
 
-  let proofData : ByteListMiB := ⟨ByteArray.mk #[], by omega⟩
+  let proofData : ByteListMiB := ⟨ByteArray.mk #[], by native_decide⟩
   let proof : AggregatedSignatureProof := {
     participants := aggBits
     proofData := proofData

--- a/test/Test/SSZ/Roundtrip.lean
+++ b/test/Test/SSZ/Roundtrip.lean
@@ -95,6 +95,26 @@ def runTests : IO (Nat × Nat) := do
   let (t, f) ← check "AggregatedSignatureProof with data roundtrip" (roundtrip aspWithData)
   total := total + t; failures := failures + f
 
+  let aggBits := Bitlist.zeros 4 (by omega : 4 ≤ VALIDATOR_REGISTRY_LIMIT)
+  let aggAtt : AggregatedAttestation := {
+    aggregationBits := aggBits
+    data := ad
+  }
+  let (t, f) ← check "AggregatedAttestation roundtrip" (roundtrip aggAtt)
+  total := total + t; failures := failures + f
+
+  let proofData : ByteListMiB := ⟨ByteArray.mk #[], by omega⟩
+  let proof : AggregatedSignatureProof := {
+    participants := aggBits
+    proofData := proofData
+  }
+  let signedAggAtt : SignedAggregatedAttestation := {
+    data := ad
+    proof := proof
+  }
+  let (t, f) ← check "SignedAggregatedAttestation roundtrip" (roundtrip signedAggAtt)
+  total := total + t; failures := failures + f
+
   return (total, failures)
 
 end Test.SSZ.Roundtrip


### PR DESCRIPTION
## Summary
- Add SSZ roundtrip tests for both `AggregatedAttestation` and `SignedAggregatedAttestation` to verify the type split from leanSpec
- Add `SignedAggregatedAttestation` handler to the LeanSpec SSZ fixture test runner

Closes #56

## Changes
- `test/Test/SSZ/Roundtrip.lean`: Add roundtrip tests for `AggregatedAttestation` (aggregationBits + data) and `SignedAggregatedAttestation` (data + proof)
- `test/Test/LeanSpec/SSZ.lean`: Add `SignedAggregatedAttestation` case to the fixture-based SSZ roundtrip dispatcher

## Context
The types `AggregatedAttestation` and `SignedAggregatedAttestation` were already correctly split in Types.lean (aligned in Epic #49), matching the leanSpec definitions. The `subnetId` field was also already absent. This PR adds the missing roundtrip test coverage required by the acceptance criteria.

## Test plan
- `lake exe test-runner` — new roundtrip tests for both attestation types should pass
- LeanSpec SSZ fixtures for `SignedAggregatedAttestation` will be picked up automatically when generated

🤖 Generated with [Claude Code](https://claude.com/claude-code)