### PR TITLE
chore: close #57 - BlockBody attestation type already refactored

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ ffi/*.a
 ffi/lean_sig_ffi/target/
 ffi/lean_sig_ffi/Cargo.lock
 ffi/lean_multisig_ffi/target/
+.github-issue-prompt.md


### PR DESCRIPTION
## Summary
- Issue 57 requested changing BlockBody.attestations from SSZList[SignedAggregatedAttestation] (limit 128) to SSZList[AggregatedAttestation] (limit 4096)
- This was already implemented in PR 63 (commit b530523) as part of Epic 49 alignment
- Verified: BlockBody uses AggregatedAttestation with MAX_ATTESTATIONS = 4096

Closes #57

## Changes
- No code changes needed - implementation already on main
- Added .github-issue-prompt.md to .gitignore

## Test plan
- Verified BlockBody.attestations type is SszList MAX_ATTESTATIONS AggregatedAttestation
- Verified MAX_ATTESTATIONS = 4096 in Constants.lean
- Verified BlockBody and AggregatedAttestation SSZ roundtrip tests exist
