### PR TITLE
refactor(leanSpec): add BlockSignatures and restructure SignedBlock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ ffi/*.a
 ffi/lean_sig_ffi/target/
 ffi/lean_sig_ffi/Cargo.lock
 ffi/lean_multisig_ffi/target/
+.github-issue-prompt.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,8 +51,8 @@ Dependent-typed collections enforce invariants at the type level:
 ### Consensus Types (`LeanConsensus/Consensus/`)
 
 - `Constants.lean` — all protocol constants as `Nat` (usable as type-level parameters)
-- `Types.lean` — full beacon chain type definitions (`BeaconState`, `BeaconBlock`, `Validator`, etc.) with manual SSZ encode/decode/hash instances using `SszEncoder`
-- `ForkChoice.lean`, `StateTransition.lean` — Phase 3 stubs
+- `Types.lean` — full beacon chain type definitions (`State`, `Block`, `SignedBlock`, `BlockSignatures`, `Validator`, etc.) with auto-derived SSZ instances
+- `ForkChoice.lean`, `StateTransition.lean` — consensus logic (slot processing, block validation, LMD-GHOST)
 
 ### Proofs (`proofs/`)
 

--- a/docs/integration.md
+++ b/docs/integration.md
@@ -1,6 +1,6 @@
 ---
 title: Integration Guide
-last_updated: 2026-03-18
+last_updated: 2026-03-21
 tags:
   - integration
   - devnet
@@ -103,9 +103,9 @@ After starting the client against a running devnet:
 ```
 lean-consensus-data/
   blocks/
-    <hex-root>.ssz     # SSZ-encoded BeaconBlock files
+    <hex-root>.ssz     # SSZ-encoded Block files
   states/
-    <hex-root>.ssz     # SSZ-encoded BeaconState files
+    <hex-root>.ssz     # SSZ-encoded State files
   store-snapshot.ssz   # Fork choice metadata for restart
 ```
 


### PR DESCRIPTION
## Summary
- BlockSignatures container wrapping attestationSignatures (SszList) and proposerSignature (XmssSignature) was added in epic 49
- SignedBlock now uses BlockSignatures instead of a single XmssSignature, matching the leanSpec
- Updated CLAUDE.md and docs/integration.md to reflect the renamed types (Block, State, SignedBlock, BlockSignatures)

Closes #58

## Changes
- **CLAUDE.md**: Updated type names from BeaconState/BeaconBlock to State/Block/SignedBlock/BlockSignatures; updated module descriptions to reflect current implementation state
- **docs/integration.md**: Updated SSZ file comments from BeaconBlock/BeaconState to Block/State
- **.gitignore**: Added .github-issue-prompt.md

## Test plan
- lake build LeanConsensus compiles successfully
- lake exe test-runner passes (including BlockSignatures and SignedBlock SSZ roundtrip fixtures)
- Verify BlockSignatures and SignedBlock types match leanSpec definition
