### PR TITLE
refactor(leanSpec): rewrite state transition logic

### DIFF
--- a/LeanConsensus/Consensus/StateTransition.lean
+++ b/LeanConsensus/Consensus/StateTransition.lean
@@ -1,11 +1,13 @@
 /-
-  State Transition — Slot and Block Processing
+  State Transition — Slot and Block Processing (leanSpec-aligned)
 
-  Implements the core state transition functions for the pq-devnet-3 beacon chain:
+  Implements the core state transition functions for the pq-devnet-3 beacon chain
+  aligned with leanSpec/src/lean_spec/subspecs/containers/state/state.py:
   - processSlot: advance state by one slot
   - processSlots: advance to a target slot
-  - processBlockHeader: validate and apply block header
-  - processAttestations: validate and apply attestations
+  - processBlockHeader: validate and apply block header (genesis, gap filling, justified slots)
+  - processAttestations: full vote tracking, supermajority justification, finalization
+  - processBlock: chain header + attestations processing
 
   Signature verification is deferred to Phase 4 (requires XMSS multisig context).
 -/
@@ -25,23 +27,26 @@ open LeanConsensus.Consensus
 inductive StateTransitionError where
   | slotMismatch (expected actual : Slot)
   | blockSlotNotFuture (stateSlot blockSlot : Slot)
+  | blockNotNewerThanParent (parentSlot blockSlot : Slot)
   | invalidProposerIndex (index : ValidatorIndex) (validatorCount : Nat)
+  | incorrectProposer (expected actual : ValidatorIndex)
   | parentRootMismatch
-  | attestationSlotTooOld (attSlot currentSlot : Slot)
-  | attestationSlotTooNew (attSlot currentSlot : Slot)
-  | invalidSourceCheckpoint
+  | noValidators
   | other (msg : String)
 
 instance : ToString StateTransitionError where
   toString
     | .slotMismatch e a => s!"slot mismatch: expected {e}, got {a}"
     | .blockSlotNotFuture ss bs => s!"block slot {bs} not future of state slot {ss}"
+    | .blockNotNewerThanParent ps bs => s!"block slot {bs} not newer than parent slot {ps}"
     | .invalidProposerIndex i c => s!"proposer index {i} >= validator count {c}"
+    | .incorrectProposer e a => s!"incorrect proposer: expected {e}, got {a}"
     | .parentRootMismatch => "parent root mismatch"
-    | .attestationSlotTooOld a c => s!"attestation slot {a} too old (current: {c})"
-    | .attestationSlotTooNew a c => s!"attestation slot {a} too new (current: {c})"
-    | .invalidSourceCheckpoint => "invalid source checkpoint"
+    | .noValidators => "no validators in state"
     | .other msg => msg
+
+instance {n : Nat} : Inhabited (BytesN n) where
+  default := BytesN.zero n
 
 -- ════════════════════════════════════════════════════════════════
 -- Helpers
@@ -55,13 +60,78 @@ def toBytes32 (data : ByteArray) : Bytes32 :=
 def isZeroRoot (r : Bytes32) : Bool :=
   r.data == (BytesN.zero 32).data
 
-/-- Convert a Block's header fields into a BeaconBlockHeader. -/
-def blockToHeader (block : Block) (bodyRoot : Bytes32) : BeaconBlockHeader :=
-  { slot := block.slot
-    proposerIndex := block.proposerIndex
-    parentRoot := block.parentRoot
-    stateRoot := block.stateRoot
-    bodyRoot := bodyRoot }
+/-- The zero root constant. -/
+def zeroRoot : Bytes32 := BytesN.zero 32
+
+-- ════════════════════════════════════════════════════════════════
+-- Slot Helpers (ported from leanSpec slot.py)
+-- ════════════════════════════════════════════════════════════════
+
+/-- Return the relative bitfield index for justification tracking.
+    Slots at or before finalized have no index (return none). -/
+def justifiedIndexAfter (slot finalized : Slot) : Option Nat :=
+  if slot ≤ finalized then none
+  else some (slot.toNat - finalized.toNat - 1)
+
+/-- Integer square root. -/
+private partial def isqrt (n : Nat) : Nat :=
+  if n == 0 then 0
+  else Id.run do
+    let mut x := n
+    let mut y := (x + 1) / 2
+    while y < x do
+      x := y
+      y := (x + n / x) / 2
+    return x
+
+/-- Check if a slot is a valid candidate for justification after a given finalized slot.
+    A slot is justifiable if delta = slot - finalized satisfies:
+    1. delta ≤ 5 (immediate window)
+    2. delta is a perfect square
+    3. delta is a pronic number (n*(n+1)) -/
+def isJustifiableAfter (slot finalized : Slot) : Bool :=
+  if slot < finalized then false
+  else
+    let delta := slot.toNat - finalized.toNat
+    delta ≤ 5
+    || isqrt delta * isqrt delta == delta
+    || (let d := 4 * delta + 1; let s := isqrt d; s * s == d && s % 2 == 1)
+
+-- ════════════════════════════════════════════════════════════════
+-- JustifiedSlots Helpers (ported from leanSpec state/types.py)
+-- ════════════════════════════════════════════════════════════════
+
+/-- Check if a slot is justified. Slots ≤ finalized are implicitly justified. -/
+def isSlotJustified (justifiedSlots : Bitlist HISTORICAL_ROOTS_LIMIT)
+    (finalized target : Slot) : Bool :=
+  match justifiedIndexAfter target finalized with
+  | none => true
+  | some idx =>
+    if h : idx < justifiedSlots.length then
+      justifiedSlots.getBit idx h
+    else false
+
+/-- Return a new bitlist with the justification status updated for a slot. -/
+def withJustified (justifiedSlots : Bitlist HISTORICAL_ROOTS_LIMIT)
+    (finalized target : Slot) (val : Bool) : Bitlist HISTORICAL_ROOTS_LIMIT :=
+  match justifiedIndexAfter target finalized with
+  | none => justifiedSlots
+  | some idx =>
+    if h : idx < justifiedSlots.length then
+      justifiedSlots.setBit idx h val
+    else justifiedSlots
+
+/-- Extend justifiedSlots so that the target slot is addressable. -/
+def extendToSlot (justifiedSlots : Bitlist HISTORICAL_ROOTS_LIMIT)
+    (finalized target : Slot) : Bitlist HISTORICAL_ROOTS_LIMIT :=
+  match justifiedIndexAfter target finalized with
+  | none => justifiedSlots
+  | some idx =>
+    let requiredLen := idx + 1
+    if requiredLen ≤ justifiedSlots.length then justifiedSlots
+    else match justifiedSlots.extendToLength requiredLen with
+      | .ok bl => bl
+      | .error _ => justifiedSlots
 
 -- ════════════════════════════════════════════════════════════════
 -- processSlot
@@ -97,27 +167,57 @@ partial def processSlots (state : State) (targetSlot : Slot) :
     .ok s
 
 -- ════════════════════════════════════════════════════════════════
--- processBlockHeader
+-- processBlockHeader (leanSpec-aligned)
 -- ════════════════════════════════════════════════════════════════
 
+/-- Push a root into an SszList, silently dropping on overflow. -/
+private def pushRoot (list : SszList HISTORICAL_ROOTS_LIMIT Root) (r : Root)
+    : SszList HISTORICAL_ROOTS_LIMIT Root :=
+  match list.push r with
+  | .ok l => l
+  | .error _ => list
+
 /-- Validate and apply a block header.
-    1. Verify state.slot == block.slot
-    2. Verify proposerIndex is valid (round-robin: slot % validators.size)
-    3. Verify parentRoot == hash_tree_root(latestBlockHeader)
-    4. Set new latestBlockHeader
-    5. Append block hash to historicalBlockHashes
-    6. Extend justifiedSlots -/
+    Aligned with leanSpec process_block_header(). -/
 def processBlockHeader (state : State) (block : Block) :
     Except StateTransitionError State := do
+  let parentHeader := state.latestBlockHeader
+  let parentRoot := toBytes32 (SszHashTreeRoot.hashTreeRoot parentHeader)
+
+  -- Validation
   if state.slot != block.slot then
     .error (.slotMismatch state.slot block.slot)
-  else if h : block.proposerIndex.toNat ≥ state.validators.elems.size then
-    .error (.invalidProposerIndex block.proposerIndex state.validators.elems.size)
+  else if block.slot ≤ parentHeader.slot then
+    .error (.blockNotNewerThanParent parentHeader.slot block.slot)
+  else if state.validators.elems.size == 0 then
+    .error .noValidators
   else
-    let expectedParentRoot := toBytes32 (SszHashTreeRoot.hashTreeRoot state.latestBlockHeader)
-    if block.parentRoot != expectedParentRoot then
+    let expectedProposer := (state.slot.toNat % state.validators.elems.size).toUInt64
+    if block.proposerIndex != expectedProposer then
+      .error (.incorrectProposer expectedProposer block.proposerIndex)
+    else if block.parentRoot != parentRoot then
       .error .parentRootMismatch
     else
+      -- Genesis parent detection
+      let isGenesisParent := parentHeader.slot == 0
+      let latestJustified :=
+        if isGenesisParent then { state.latestJustified with root := parentRoot }
+        else state.latestJustified
+      let latestFinalized :=
+        if isGenesisParent then { state.latestFinalized with root := parentRoot }
+        else state.latestFinalized
+
+      -- Historical data: append parent root + zero hashes for gaps
+      let numEmptySlots := block.slot.toNat - parentHeader.slot.toNat - 1
+      let mut hashes := pushRoot state.historicalBlockHashes parentRoot
+      for _ in [:numEmptySlots] do
+        hashes := pushRoot hashes zeroRoot
+
+      -- Extend justified slots to cover up to block.slot - 1
+      let lastMaterializedSlot := block.slot - 1
+      let justifiedSlots := extendToSlot state.justifiedSlots latestFinalized.slot lastMaterializedSlot
+
+      -- New header with empty state root
       let bodyRoot := toBytes32 (SszHashTreeRoot.hashTreeRoot block.body)
       let newHeader : BeaconBlockHeader :=
         { slot := block.slot
@@ -125,32 +225,207 @@ def processBlockHeader (state : State) (block : Block) :
           parentRoot := block.parentRoot
           stateRoot := BytesN.zero 32
           bodyRoot := bodyRoot }
-      let blockHash := toBytes32 (SszHashTreeRoot.hashTreeRoot block)
-      let historicalBlockHashes := match state.historicalBlockHashes.push blockHash with
-        | .ok list => list
-        | .error _ => state.historicalBlockHashes
+
       .ok { state with
         latestBlockHeader := newHeader
-        historicalBlockHashes := historicalBlockHashes }
+        latestJustified := latestJustified
+        latestFinalized := latestFinalized
+        historicalBlockHashes := hashes
+        justifiedSlots := justifiedSlots }
 
 -- ════════════════════════════════════════════════════════════════
--- processAttestations
+-- processAttestations (leanSpec-aligned)
 -- ════════════════════════════════════════════════════════════════
+
+/-- Unflatten justificationsValidators into per-root vote arrays.
+    Returns Array (Root × Array Bool). -/
+private def unflattenVotes (roots : Array Root) (validators : Bitlist (HISTORICAL_ROOTS_LIMIT * VALIDATOR_REGISTRY_LIMIT))
+    (numValidators : Nat) : Array (Root × Array Bool) := Id.run do
+  let mut result := #[]
+  for i in [:roots.size] do
+    let root := roots[i]!
+    let start := i * numValidators
+    let mut votes := Array.replicate numValidators false
+    for j in [:numValidators] do
+      let srcIdx := start + j
+      if srcIdx < validators.length then
+        if h : srcIdx < validators.length then
+          votes := votes.set! j (validators.getBit srcIdx h)
+    result := result.push (root, votes)
+  return result
+
+/-- Compare two BytesN lexicographically. -/
+private def bytesLt (a b : Bytes32) : Bool := Id.run do
+  for i in [:32] do
+    let av := a.data.get! i
+    let bv := b.data.get! i
+    if av < bv then return true
+    if av > bv then return false
+  return false
+
+/-- Re-flatten vote structure back to sorted roots + flat bitlist. -/
+private def flattenVotes (justifications : Array (Root × Array Bool))
+    : Array Root × Array Bool := Id.run do
+  let sorted := justifications.qsort fun a b => bytesLt a.1 b.1
+  let mut roots := #[]
+  let mut allVotes := #[]
+  for (root, votes) in sorted do
+    roots := roots.push root
+    allVotes := allVotes ++ votes
+  return (roots, allVotes)
+
+/-- Build a rootToSlot map from historical block hashes. -/
+private def buildRootToSlot (hashes : Array Root) (startSlot : Nat)
+    : Array (Root × Nat) := Id.run do
+  let mut result := #[]
+  for i in [startSlot:hashes.size] do
+    result := result.push (hashes[i]!, i)
+  return result
+
+/-- Look up a slot for a root in the rootToSlot map. -/
+private def lookupSlot (rootToSlot : Array (Root × Nat)) (root : Root) : Option Nat :=
+  rootToSlot.foldl (fun acc (r, s) => if r == root then some s else acc) none
+
+/-- Count true values in a Bool array. -/
+private def countVotes (votes : Array Bool) : Nat :=
+  votes.foldl (fun acc v => if v then acc + 1 else acc) 0
 
 /-- Process attestations from a block body.
     Per-validator vote tracking via justificationsRoots/justificationsValidators.
-    Supermajority justification and finalization advancement. -/
+    Supermajority justification and finalization advancement.
+
+    Invalid attestations are silently skipped (soft-skip), matching leanSpec behavior. -/
 def processAttestations (state : State) (attestations : Array AggregatedAttestation) :
     Except StateTransitionError State := do
-  let mut s := state
+  let numValidators := state.validators.elems.size
+  let hashesArr := state.historicalBlockHashes.elems
+
+  -- Unflatten vote structure
+  let mut justifications := unflattenVotes state.justificationsRoots.elems
+    state.justificationsValidators numValidators
+
+  -- Track mutable state
+  let mut latestJustified := state.latestJustified
+  let mut latestFinalized := state.latestFinalized
+  let mut finalizedSlot := latestFinalized.slot
+  let mut justifiedSlots := state.justifiedSlots
+
+  -- Build rootToSlot map
+  let startSlot := finalizedSlot.toNat + 1
+  let rootToSlot := buildRootToSlot hashesArr startSlot
+
+  -- Process each attestation
   for att in attestations do
-    if att.data.slot > s.slot then
-      throw (.attestationSlotTooNew att.data.slot s.slot)
-    if s.slot - att.data.slot > SLOTS_TO_FINALITY.toUInt64 then
-      throw (.attestationSlotTooOld att.data.slot s.slot)
-    if att.data.source != s.latestJustified then
-      throw .invalidSourceCheckpoint
-  .ok s
+    let source := att.data.source
+    let target := att.data.target
+
+    -- Skip if source not justified
+    if !isSlotJustified justifiedSlots finalizedSlot source.slot then
+      continue
+
+    -- Skip if target already justified
+    if isSlotJustified justifiedSlots finalizedSlot target.slot then
+      continue
+
+    -- Skip zero-hash roots
+    if isZeroRoot source.root || isZeroRoot target.root then
+      continue
+
+    -- Bounds-safe history lookups
+    let sourceSlotNat := source.slot.toNat
+    let targetSlotNat := target.slot.toNat
+    if sourceSlotNat ≥ hashesArr.size || targetSlotNat ≥ hashesArr.size then
+      continue
+
+    -- Check roots match historical records
+    if source.root != hashesArr[sourceSlotNat]! || target.root != hashesArr[targetSlotNat]! then
+      continue
+
+    -- Time must flow forward
+    if target.slot ≤ source.slot then
+      continue
+
+    -- Target must be justifiable
+    if !isJustifiableAfter target.slot finalizedSlot then
+      continue
+
+    -- Get validator indices from aggregation bits
+    let validatorIndices := att.aggregationBits.toIndices
+    if validatorIndices.isEmpty then
+      continue
+
+    -- Find or create vote entry for target root
+    let mut found := false
+    let mut justIdx := 0
+    for i in [:justifications.size] do
+      if (justifications[i]!).1 == target.root then
+        found := true
+        justIdx := i
+        break
+
+    if !found then
+      justifications := justifications.push (target.root, Array.replicate numValidators false)
+      justIdx := justifications.size - 1
+
+    -- Record votes
+    let entry := justifications[justIdx]!
+    let entryRoot := entry.1
+    let mut votes := entry.2
+    for vi in validatorIndices do
+      if vi < numValidators then
+        votes := votes.set! vi true
+    justifications := justifications.set! justIdx (entryRoot, votes)
+
+    -- Check supermajority: 3 * count >= 2 * total
+    let count := countVotes votes
+    if 3 * count ≥ 2 * numValidators then
+      -- Target becomes justified
+      latestJustified := target
+      justifiedSlots := withJustified justifiedSlots finalizedSlot target.slot true
+
+      -- Remove vote entry for justified root
+      justifications := justifications.filter fun (r, _) => r != target.root
+
+      -- Check finalization: no justifiable slot gap between source and target
+      let hasGap := Id.run do
+        let mut gap := false
+        for s in [source.slot.toNat + 1 : target.slot.toNat] do
+          if isJustifiableAfter s.toUInt64 finalizedSlot then
+            gap := true
+            break
+        return gap
+
+      if !hasGap then
+        let oldFinalizedSlot := finalizedSlot
+        latestFinalized := source
+        finalizedSlot := latestFinalized.slot
+        let delta := finalizedSlot.toNat - oldFinalizedSlot.toNat
+        if delta > 0 then
+          justifiedSlots := justifiedSlots.shiftWindow delta
+          -- Prune old vote entries
+          justifications := justifications.filter fun (r, _) =>
+            match lookupSlot rootToSlot r with
+            | some s => s > finalizedSlot.toNat
+            | none => false
+
+  -- Re-flatten vote structure
+  let (sortedRoots, allVotes) := flattenVotes justifications
+
+  -- Build output SszLists and Bitlist
+  let justRoots := match SszList.mkChecked (maxCap := HISTORICAL_ROOTS_LIMIT) sortedRoots with
+    | .ok l => l
+    | .error _ => SszList.empty
+  let justVals := if h : allVotes.size ≤ HISTORICAL_ROOTS_LIMIT * VALIDATOR_REGISTRY_LIMIT then
+      Bitlist.fromBools allVotes h
+    else
+      Bitlist.empty (HISTORICAL_ROOTS_LIMIT * VALIDATOR_REGISTRY_LIMIT)
+
+  .ok { state with
+    justificationsRoots := justRoots
+    justificationsValidators := justVals
+    justifiedSlots := justifiedSlots
+    latestJustified := latestJustified
+    latestFinalized := latestFinalized }
 
 -- ════════════════════════════════════════════════════════════════
 -- processBlock

--- a/LeanConsensus/SSZ/Bitlist.lean
+++ b/LeanConsensus/SSZ/Bitlist.lean
@@ -112,6 +112,153 @@ def sszDecodeImpl {maxCap : Nat} (data : ByteArray) : Except SszError (Bitlist m
       else
         .error (.capacityExceeded maxCap length)
 
+/-- Set a bit at index `i` to the given value. Requires `i < bl.length`. -/
+def setBit {maxCap : Nat} (bl : Bitlist maxCap) (i : Nat) (_h : i < bl.length) (val : Bool) : Bitlist maxCap :=
+  let byteIdx := i / 8
+  let bitIdx := i % 8
+  let oldByte := bl.data.get! byteIdx
+  let mask := (1 : UInt8) <<< bitIdx.toUInt8
+  let newByte := if val then oldByte ||| mask else oldByte &&& mask.complement
+  let newData := bl.data.set! byteIdx newByte
+  if hsize : newData.size = (bl.length + 7) / 8 then
+    ⟨newData, bl.length, bl.hbound, hsize⟩
+  else
+    bl
+
+/-- Extend bitlist to `n` bits, zero-filling new positions. No-op if `n ≤ bl.length`. -/
+def extendToLength {maxCap : Nat} (bl : Bitlist maxCap) (n : Nat) :
+    Except SszError (Bitlist maxCap) :=
+  if n ≤ bl.length then .ok bl
+  else if h : n ≤ maxCap then
+    let newByteCount := (n + 7) / 8
+    let result := Id.run do
+      let mut r := ByteArray.mk (Array.replicate newByteCount 0)
+      for i in [:bl.length] do
+        let byteIdx := i / 8
+        let bitIdx := i % 8
+        let srcByte := bl.data.get! byteIdx
+        if (srcByte >>> bitIdx.toUInt8) &&& 1 == 1 then
+          let dstByte := r.get! byteIdx
+          r := r.set! byteIdx (dstByte ||| ((1 : UInt8) <<< bitIdx.toUInt8))
+      return r
+    if hsize : result.size = (n + 7) / 8 then
+      .ok ⟨result, n, h, hsize⟩
+    else
+      .error (.other "bitlist extendToLength: unexpected size")
+  else
+    .error (.capacityExceeded maxCap n)
+
+/-- Drop the first `delta` bits, returning a shorter bitlist. -/
+def shiftWindow {maxCap : Nat} (bl : Bitlist maxCap) (delta : Nat) : Bitlist maxCap :=
+  if delta == 0 then bl
+  else if delta ≥ bl.length then empty maxCap
+  else
+    let newLen := bl.length - delta
+    let newByteCount := (newLen + 7) / 8
+    let result := Id.run do
+      let mut r := ByteArray.mk (Array.replicate newByteCount 0)
+      for i in [:newLen] do
+        let srcIdx := i + delta
+        let srcByteIdx := srcIdx / 8
+        let srcBitIdx := srcIdx % 8
+        let srcByte := bl.data.get! srcByteIdx
+        if (srcByte >>> srcBitIdx.toUInt8) &&& 1 == 1 then
+          let dstByteIdx := i / 8
+          let dstBitIdx := i % 8
+          let dstByte := r.get! dstByteIdx
+          r := r.set! dstByteIdx (dstByte ||| ((1 : UInt8) <<< dstBitIdx.toUInt8))
+      return r
+    if hsize : result.size = (newLen + 7) / 8 then
+      have hle : newLen ≤ maxCap := Nat.le_trans (Nat.sub_le bl.length delta) bl.hbound
+      ⟨result, newLen, hle, hsize⟩
+    else
+      empty maxCap
+
+/-- Return an array of indices where bits are set. -/
+def toIndices {maxCap : Nat} (bl : Bitlist maxCap) : Array Nat := Id.run do
+  let mut result := #[]
+  for i in [:bl.length] do
+    let byteIdx := i / 8
+    let bitIdx := i % 8
+    let byte := bl.data.get! byteIdx
+    if (byte >>> bitIdx.toUInt8) &&& 1 == 1 then
+      result := result.push i
+  return result
+
+/-- Extract bits `[start, start+len)` as a new Bitlist.
+    Out-of-range source bits are treated as 0. -/
+def sliceSegment {maxCap : Nat} (bl : Bitlist maxCap) (start len : Nat)
+    {outCap : Nat} (hcap : len ≤ outCap) : Bitlist outCap :=
+  let newByteCount := (len + 7) / 8
+  let result := Id.run do
+    let mut r := ByteArray.mk (Array.replicate newByteCount 0)
+    for i in [:len] do
+      let srcIdx := start + i
+      if srcIdx < bl.length then
+        let srcByteIdx := srcIdx / 8
+        let srcBitIdx := srcIdx % 8
+        let srcByte := bl.data.get! srcByteIdx
+        if (srcByte >>> srcBitIdx.toUInt8) &&& 1 == 1 then
+          let dstByteIdx := i / 8
+          let dstBitIdx := i % 8
+          let dstByte := r.get! dstByteIdx
+          r := r.set! dstByteIdx (dstByte ||| ((1 : UInt8) <<< dstBitIdx.toUInt8))
+    return r
+  if hsize : result.size = (len + 7) / 8 then
+    ⟨result, len, hcap, hsize⟩
+  else
+    zeros len hcap
+
+/-- Create a bitlist from an array of Bool values. -/
+def fromBools {maxCap : Nat} (vals : Array Bool) (hcap : vals.size ≤ maxCap) : Bitlist maxCap :=
+  let len := vals.size
+  let byteCount := (len + 7) / 8
+  let result := Id.run do
+    let mut r := ByteArray.mk (Array.replicate byteCount 0)
+    for i in [:len] do
+      if vals[i]! then
+        let byteIdx := i / 8
+        let bitIdx := i % 8
+        let byte := r.get! byteIdx
+        r := r.set! byteIdx (byte ||| ((1 : UInt8) <<< bitIdx.toUInt8))
+    return r
+  if hsize : result.size = (len + 7) / 8 then
+    ⟨result, len, hcap, hsize⟩
+  else
+    zeros len hcap
+
+/-- Concatenate two bitlists. -/
+def concat {maxCap : Nat} (a b : Bitlist maxCap) : Except SszError (Bitlist maxCap) :=
+  let newLen := a.length + b.length
+  if h : newLen ≤ maxCap then
+    let newByteCount := (newLen + 7) / 8
+    let result := Id.run do
+      let mut r := ByteArray.mk (Array.replicate newByteCount 0)
+      for i in [:a.length] do
+        let byteIdx := i / 8
+        let bitIdx := i % 8
+        let srcByte := a.data.get! byteIdx
+        if (srcByte >>> bitIdx.toUInt8) &&& 1 == 1 then
+          let dstByte := r.get! i / 8
+          r := r.set! (i / 8) (dstByte ||| ((1 : UInt8) <<< (i % 8).toUInt8))
+      for j in [:b.length] do
+        let dstIdx := a.length + j
+        let srcByteIdx := j / 8
+        let srcBitIdx := j % 8
+        let srcByte := b.data.get! srcByteIdx
+        if (srcByte >>> srcBitIdx.toUInt8) &&& 1 == 1 then
+          let dstByteIdx := dstIdx / 8
+          let dstBitIdx := dstIdx % 8
+          let dstByte := r.get! dstByteIdx
+          r := r.set! dstByteIdx (dstByte ||| ((1 : UInt8) <<< dstBitIdx.toUInt8))
+      return r
+    if hsize : result.size = (newLen + 7) / 8 then
+      .ok ⟨result, newLen, h, hsize⟩
+    else
+      .error (.other "bitlist concat: unexpected size")
+  else
+    .error (.capacityExceeded maxCap newLen)
+
 end Bitlist
 
 -- SSZ instances: Bitlist is variable-size

--- a/test/Test/Consensus/ForkChoice.lean
+++ b/test/Test/Consensus/ForkChoice.lean
@@ -97,7 +97,7 @@ def runTests : IO (Nat × Nat) := do
     let store := fromAnchor genesis genesisBlock
     let genesisRoot := blockRoot genesisBlock
     let block1 : Block :=
-      { slot := 1, proposerIndex := 0
+      { slot := 1, proposerIndex := 1
         parentRoot := genesisRoot
         stateRoot := Bytes32.zero
         body := { attestations := SszList.empty } }

--- a/test/Test/Consensus/StateTransition.lean
+++ b/test/Test/Consensus/StateTransition.lean
@@ -1,5 +1,5 @@
 /-
-  State Transition Tests
+  State Transition Tests (leanSpec-aligned)
 -/
 
 import LeanConsensus.Consensus.StateTransition
@@ -97,7 +97,7 @@ def runTests : IO (Nat × Nat) := do
     let parentRoot := toBytes32 (SszHashTreeRoot.hashTreeRoot s1.latestBlockHeader)
     let block : Block :=
       { slot := 1
-        proposerIndex := 0
+        proposerIndex := (1 % 4 : UInt64)
         parentRoot := parentRoot
         stateRoot := Bytes32.zero
         body := { attestations := SszList.empty } }
@@ -135,7 +135,7 @@ def runTests : IO (Nat × Nat) := do
     let s1 := processSlot genesis
     let block : Block :=
       { slot := 1
-        proposerIndex := 0
+        proposerIndex := (1 % 4 : UInt64)
         parentRoot := Bytes32.zero
         stateRoot := Bytes32.zero
         body := { attestations := SszList.empty } }
@@ -150,7 +150,98 @@ def runTests : IO (Nat × Nat) := do
       let (t, f) ← check "processBlock rejects invalid parent root (wrong error)" false
       total := total + t; failures := failures + f
 
-  -- Test 7: processAttestation rejects future attestation
+  -- Test 7: isJustifiableAfter — immediate window (0-5)
+  do
+    let ok := isJustifiableAfter 0 0 && isJustifiableAfter 5 0
+        && isJustifiableAfter 3 0 && isJustifiableAfter 1 0
+    let (t, f) ← check "isJustifiableAfter immediate window 0-5" ok
+    total := total + t; failures := failures + f
+
+  -- Test 8: isJustifiableAfter — perfect squares
+  do
+    let ok := isJustifiableAfter 9 0 && isJustifiableAfter 16 0
+        && isJustifiableAfter 25 0
+    let (t, f) ← check "isJustifiableAfter perfect squares (9,16,25)" ok
+    total := total + t; failures := failures + f
+
+  -- Test 9: isJustifiableAfter — pronic numbers
+  do
+    let ok := isJustifiableAfter 6 0 && isJustifiableAfter 12 0
+        && isJustifiableAfter 20 0
+    let (t, f) ← check "isJustifiableAfter pronic numbers (6,12,20)" ok
+    total := total + t; failures := failures + f
+
+  -- Test 10: isJustifiableAfter — non-justifiable slots
+  do
+    let ok := !isJustifiableAfter 7 0 && !isJustifiableAfter 8 0
+        && !isJustifiableAfter 10 0 && !isJustifiableAfter 11 0
+    let (t, f) ← check "isJustifiableAfter rejects 7,8,10,11" ok
+    total := total + t; failures := failures + f
+
+  -- Test 11: justifiedIndexAfter
+  do
+    let ok1 := justifiedIndexAfter 0 0 == none
+    let ok2 := justifiedIndexAfter 5 5 == none
+    let ok3 := justifiedIndexAfter 3 0 == some 2
+    let ok4 := justifiedIndexAfter 1 0 == some 0
+    let ok5 := justifiedIndexAfter 10 5 == some 4
+    let (t, f) ← check "justifiedIndexAfter" (ok1 && ok2 && ok3 && ok4 && ok5)
+    total := total + t; failures := failures + f
+
+  -- Test 12: Genesis parent detection — first block sets justified/finalized roots
+  do
+    let s1 := processSlot genesis
+    let parentRoot := toBytes32 (SszHashTreeRoot.hashTreeRoot s1.latestBlockHeader)
+    let block : Block :=
+      { slot := 1
+        proposerIndex := (1 % 4 : UInt64)
+        parentRoot := parentRoot
+        stateRoot := Bytes32.zero
+        body := { attestations := SszList.empty } }
+    match processBlockHeader s1 block with
+    | .ok s2 =>
+      let justifiedRootSet := s2.latestJustified.root == parentRoot
+      let finalizedRootSet := s2.latestFinalized.root == parentRoot
+      let (t, f) ← check "genesis parent sets justified/finalized roots"
+        (justifiedRootSet && finalizedRootSet)
+      total := total + t; failures := failures + f
+    | .error e =>
+      let (t, f) ← check s!"genesis parent detection (error: {e})" false
+      total := total + t; failures := failures + f
+
+  -- Test 13: Gap filling — skipped slots produce zero hashes
+  do
+    match processSlots genesis 3 with
+    | .ok s3 =>
+      let parentRoot := toBytes32 (SszHashTreeRoot.hashTreeRoot s3.latestBlockHeader)
+      let block : Block :=
+        { slot := 3
+          proposerIndex := (3 % 4 : UInt64)
+          parentRoot := parentRoot
+          stateRoot := Bytes32.zero
+          body := { attestations := SszList.empty } }
+      match processBlockHeader s3 block with
+      | .ok s4 =>
+        -- Genesis header slot=0, block slot=3: gap = 3-0-1 = 2 empty slots
+        -- historicalBlockHashes should have: [parentRoot, zeroRoot, zeroRoot]
+        let hasHistory := s4.historicalBlockHashes.elems.size == 3
+        let firstIsParent := s4.historicalBlockHashes.elems.size > 0 &&
+          s4.historicalBlockHashes.elems[0]! == parentRoot
+        let secondIsZero := s4.historicalBlockHashes.elems.size > 1 &&
+          isZeroRoot s4.historicalBlockHashes.elems[1]!
+        let thirdIsZero := s4.historicalBlockHashes.elems.size > 2 &&
+          isZeroRoot s4.historicalBlockHashes.elems[2]!
+        let (t, f) ← check "gap filling with zero hashes"
+          (hasHistory && firstIsParent && secondIsZero && thirdIsZero)
+        total := total + t; failures := failures + f
+      | .error e =>
+        let (t, f) ← check s!"gap filling (error: {e})" false
+        total := total + t; failures := failures + f
+    | .error e =>
+      let (t, f) ← check s!"gap filling setup (error: {e})" false
+      total := total + t; failures := failures + f
+
+  -- Test 14: Soft-skip attestations — invalid attestations leave state unchanged
   do
     let s1 := processSlot genesis
     let futureData : AttestationData :=
@@ -161,33 +252,53 @@ def runTests : IO (Nat × Nat) := do
       { aggregationBits := Bitlist.empty VALIDATOR_REGISTRY_LIMIT
         data := futureData }
     match processAttestations s1 #[futureAtt] with
-    | .error (.attestationSlotTooNew _ _) =>
-      let (t, f) ← check "processAttestation rejects future attestation" true
+    | .ok s2 =>
+      let unchanged := s2.latestJustified == s1.latestJustified
+        && s2.latestFinalized == s1.latestFinalized
+      let (t, f) ← check "soft-skip invalid attestations" unchanged
       total := total + t; failures := failures + f
-    | _ =>
-      let (t, f) ← check "processAttestation rejects future attestation" false
+    | .error e =>
+      let (t, f) ← check s!"soft-skip attestations (unexpected error: {e})" false
       total := total + t; failures := failures + f
 
-  -- Test 8: processAttestation rejects too-old attestation
+  -- Test 15: Out-of-bounds attestation references are silently skipped
   do
-    match processSlots genesis 10 with
-    | .ok s10 =>
-      let oldData : AttestationData :=
-        { slot := 1, head := s10.latestJustified
-          source := s10.latestJustified
-          target := s10.latestJustified }
-      let oldAtt : AggregatedAttestation :=
-        { aggregationBits := Bitlist.empty VALIDATOR_REGISTRY_LIMIT
-          data := oldData }
-      match processAttestations s10 #[oldAtt] with
-      | .error (.attestationSlotTooOld _ _) =>
-        let (t, f) ← check "processAttestation rejects too-old attestation" true
-        total := total + t; failures := failures + f
-      | _ =>
-        let (t, f) ← check "processAttestation rejects too-old attestation" false
-        total := total + t; failures := failures + f
+    let s1 := processSlot genesis
+    let oobCheckpoint : Checkpoint := { root := Bytes32.zero, slot := 9999 }
+    let oobData : AttestationData :=
+      { slot := 1, head := oobCheckpoint
+        source := oobCheckpoint
+        target := oobCheckpoint }
+    let oobAtt : AggregatedAttestation :=
+      { aggregationBits := Bitlist.empty VALIDATOR_REGISTRY_LIMIT
+        data := oobData }
+    match processAttestations s1 #[oobAtt] with
+    | .ok _ =>
+      let (t, f) ← check "out-of-bounds attestation silently skipped" true
+      total := total + t; failures := failures + f
+    | .error e =>
+      let (t, f) ← check s!"out-of-bounds attestation (unexpected error: {e})" false
+      total := total + t; failures := failures + f
+
+  -- Test 16: processBlock rejects incorrect proposer
+  do
+    let s1 := processSlot genesis
+    let parentRoot := toBytes32 (SszHashTreeRoot.hashTreeRoot s1.latestBlockHeader)
+    let block : Block :=
+      { slot := 1
+        proposerIndex := 3
+        parentRoot := parentRoot
+        stateRoot := Bytes32.zero
+        body := { attestations := SszList.empty } }
+    match processBlock s1 block with
+    | .ok _ =>
+      let (t, f) ← check "processBlock rejects incorrect proposer" false
+      total := total + t; failures := failures + f
+    | .error (.incorrectProposer _ _) =>
+      let (t, f) ← check "processBlock rejects incorrect proposer" true
+      total := total + t; failures := failures + f
     | .error _ =>
-      let (t, f) ← check "processAttestation rejects too-old (setup failed)" false
+      let (t, f) ← check "processBlock rejects incorrect proposer (wrong error)" false
       total := total + t; failures := failures + f
 
   return (total, failures)


### PR DESCRIPTION
## Summary
- Full rewrite of `processBlockHeader` and `processAttestations` in `StateTransition.lean` aligned with leanSpec `state.py`
- Adds genesis parent detection, historical gap filling, justified slots tracking, per-validator vote counting with supermajority justification, and finalization advancement with pruning
- Adds Bitlist helpers (`setBit`, `extendToLength`, `shiftWindow`, `toIndices`, `sliceSegment`, `fromBools`, `concat`) and slot justifiability helpers (`justifiedIndexAfter`, `isJustifiableAfter`)
- Invalid attestations now use soft-skip (silently ignored) instead of hard errors, matching leanSpec behavior

Closes #60

## Test plan
- [x] `lake build LeanConsensus` compiles cleanly
- [x] `lake exe test-runner` — 214/214 tests pass
- [x] `lake build Proofs` — proof stubs compile
- [x] New tests: `isJustifiableAfter` (immediate window, perfect squares, pronic numbers, rejections)
- [x] New tests: `justifiedIndexAfter` relative index computation
- [x] New tests: genesis parent sets justified/finalized roots
- [x] New tests: gap filling with zero hashes for skipped slots
- [x] New tests: soft-skip invalid attestations (no error, state unchanged)
- [x] New tests: out-of-bounds attestation references silently skipped
- [x] New tests: incorrect proposer rejection
- [x] Fixed fork choice test for new round-robin proposer check

🤖 Generated with [Claude Code](https://claude.com/claude-code)